### PR TITLE
Add Custom Machine Type sample

### DIFF
--- a/examples/v2/custom_machine_type/README.md
+++ b/examples/v2/custom_machine_type/README.md
@@ -1,0 +1,6 @@
+# Custom Machine Type Sample
+
+This is an example of specifying the machine type to create a VM with 4 CPUs and 5GB (5120 MB) of memory.
+
+See:
+https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type

--- a/examples/v2/custom_machine_type/vm.yaml
+++ b/examples/v2/custom_machine_type/vm.yaml
@@ -1,0 +1,22 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: vm_template.jinja
+
+resources:
+- name: vm_template
+  type: vm_template.jinja
+  properties:
+    zone: ZONE_TO_RUN

--- a/examples/v2/custom_machine_type/vm_template.jinja
+++ b/examples/v2/custom_machine_type/vm_template.jinja
@@ -1,0 +1,37 @@
+{#
+Copyright 2016 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+# Creates a Persistent VM
+resources:
+- type: compute.v1.instance
+  name: vm-{{ env["deployment"] }}
+  properties:
+    zone: {{ properties["zone"] }}
+    # Note the machineType definition at the end. custom-4-5120 specifies 4 CPUs and 5GB (5120 MB) of RAM
+    machineType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/machineTypes/custom-4-5120
+    disks:
+    - deviceName: boot
+      type: PERSISTENT
+      boot: true
+      autoDelete: true
+      initializeParams:
+        diskName: disk-{{ env["deployment"] }}
+        sourceImage: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20140619
+    networkInterfaces:
+    - network: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/global/networks/default
+      # Access Config required to give the instance a public IP address
+      accessConfigs:
+      - name: External NAT
+        type: ONE_TO_ONE_NAT

--- a/examples/v2/custom_machine_type/vm_template.jinja.schema
+++ b/examples/v2/custom_machine_type/vm_template.jinja.schema
@@ -1,0 +1,26 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+info:
+  title: Single Custom Machine Type
+  author: Google Inc.
+  description: Creates a disk with custom amount of memory and number of CPUs (4 CPU, 5120MB/5GB RAM)
+
+required:
+  - zone
+
+properties:
+  zone:
+    description: Zone to create the resources in.
+    type: string


### PR DESCRIPTION
I have an OKR to create a deployment manager sample with custom VMs.

I have since realize it's really trivial (just give the machine type a special name), so maybe this sample isn't necessary. It's very similar to the single_vm example. I will leave it up to this repo owner to decide whether to accept it.
