### PR TITLE
name is now required

### DIFF
--- a/examples/v2/project_creation/project.py
+++ b/examples/v2/project_creation/project.py
@@ -68,7 +68,8 @@ def GenerateConfig(context):
           'name': bucket_name,
           'type': 'gcp-types/storage-v1:buckets',
           'properties': {
-              'project': project_id
+              'project': project_id,
+              'name': bucket_name
           },
           'metadata': {
               'dependsOn': [project_id]


### PR DESCRIPTION
otherwise you get the following error:

- code: CONDITION_NOT_MET
  location: /deployments/projects/resources/PROJECT-export-bucket->$.properties
  message: '"": domain: validation; keyword: properties; message: required property(ies)
    not found; missing: ["name"]; required: ["name"]'