### PR TITLE
Specify project name

### DIFF
--- a/examples/v2/project_creation/project.py
+++ b/examples/v2/project_creation/project.py
@@ -24,6 +24,7 @@ def GenerateConfig(context):
       'name': project_id,
       'type': 'cloudresourcemanager.v1.project',
       'properties': {
+          'name': project_id,
           'projectId': project_id,
           'parent': {
               'type': 'organization',


### PR DESCRIPTION
Without this you cannot create a new Stackdriver on this project as the project name field is empty. In the account creation wizard, Stackdriver complains on the POST call to https://app.google.stackdriver.com/api/workspaces with {name: ["This field is required."]}.