### PR TITLE
Fix incorrect api endpoint

### DIFF
--- a/examples/v2/project_creation/config.yaml
+++ b/examples/v2/project_creation/config.yaml
@@ -13,7 +13,7 @@ resources:
     # The apis to enable in the new project.
     # To see the possible APIs, use gcloud CLI: gcloud service-management list
     apis:
-    - compute-component.googleapis.com
+    - compute.googleapis.com
     - deploymentmanager.googleapis.com
     - pubsub.googleapis.com
     - storage-component.googleapis.com


### PR DESCRIPTION
Enable compute.googleapis.com instead of compute-component.googleapis.com. The latter is no longer available.