### PR TITLE
Add an access control example

### DIFF
--- a/examples/v2/access_control/README.md
+++ b/examples/v2/access_control/README.md
@@ -1,0 +1,26 @@
+# Access control example
+
+## Overview
+
+This [Google Cloud Deployment
+Manager](https://cloud.google.com/deployment-manager/overview) template
+deploys a PubSub topic and limits the permissions using a DM access control
+section.
+
+Note that the access control section gives the service account admin privileges.
+This is important so DM can make changes to the resource later.
+
+## Deploy the template
+
+Use `access_control.jinja` to deploy this example template. Fill in `YOUR_EMAIL_HERE`
+with your email to retain permissions to the resource (if using DM, you
+technically only need the service account). Note there should be no space between
+`user:` and your email.
+
+When ready, deploy with the following command:
+
+    gcloud deployment-manager deployments create my-access-control-test --template access_control.jinja
+
+## More information
+
+[Access Control Documentation](https://cloud.google.com/deployment-manager/docs/configuration/set-access-control-resources)

--- a/examples/v2/access_control/access_control.jinja
+++ b/examples/v2/access_control/access_control.jinja
@@ -1,0 +1,15 @@
+resources:
+- name: my-topic
+  type: pubsub.v1.topic
+  properties:
+    topic: {{ env['deployment'] }}-topic
+  accessControl:
+    gcpIamPolicy:
+      bindings:
+        - members:
+          - user:YOUR_EMAIL_HERE
+          # The default Deployment Manager service account should retain permissions.
+          # Replace this with a different value if you use DM with different
+          # credentials.
+          - serviceAccount:{{ env['project_number'] }}@cloudservices.gserviceaccount.com
+          role: roles/pubsub.admin


### PR DESCRIPTION
Only a jinja template is provided because this is _very_ short, but
still requires variables to grab the project number.