### PR TITLE
Fix an issue in getIamPolicy method

### DIFF
--- a/examples/v2/project_creation/project.py
+++ b/examples/v2/project_creation/project.py
@@ -82,8 +82,11 @@ def GenerateConfig(context):
       }
   }]
   if context.properties.get('set-dm-service-account-as-owner'):
+      # The name needs to be different in every update
+      # due to a known issue in DM.
+      get_iam_policy_name = 'get-iam-policy-' + str(context.env['current_time'])
       resources.extend([{
-          'name': 'get-iam-policy',
+          'name': get_iam_policy_name,
           'action': 'gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.getIamPolicy',
           'properties': {
             'resource': project_id,
@@ -99,7 +102,7 @@ def GenerateConfig(context):
           'action': 'gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.setIamPolicy',
           'properties': {
             'resource': project_id,
-            'policy': '$(ref.get-iam-policy)',
+            'policy': '$(ref.' + get_iam_policy_name + ')',
             'gcpIamPolicyPatch': {
                'add': [{
                  'role': 'roles/owner',

--- a/examples/v2/project_creation/test_project.py
+++ b/examples/v2/project_creation/test_project.py
@@ -11,7 +11,9 @@ class Context:
 
 class ProjectTestCase(unittest.TestCase):
   """Tests for `project.py`."""
-  default_env = {'name': 'my-project', 'project_number': '1234'}
+  default_env = {'name': 'my-project',
+                 'project_number': '1234',
+                 'current_time': 0}
   default_properties = {
       'organization-id': "1234",
       'billing-account-name': 'foo',


### PR DESCRIPTION
The response of getIamPolicy method is not updated if we use the same reference name (e.g. "$(ref.get-iam-policy)") in Deployment Manager. We work around the issue by giving a different name with the suffix of timestamp in every deployment update.