### PR TITLE
Add examples for organization custom roles in Deployment Manager.

### DIFF
--- a/examples/v2/iam_custom_role/README.md
+++ b/examples/v2/iam_custom_role/README.md
@@ -8,10 +8,15 @@ deploys a custom role.
 
 ## Deploy the template
 
-Use `project_custom_role.yaml` to deploy this example template.
-
-When ready, deploy with the following command:
+When ready, deploy a project custom role with the following command:
 
     gcloud deployment-manager deployments create YOUR_DEPLOYMENT_NAME --config project_custom_role.yaml
+
+or deploy an organization custom role with the following command:
+
+    gcloud deployment-manager deployments create YOUR_DEPLOYMENT_NAME --config organization_custom_role.yaml
+
+When using `organization_custom_role.yaml`, the organizationId field needs to
+be populated with the organization id where the custom role will be created under.
 
 See more documentation at [IAM Roles](https://cloud.google.com/iam/reference/rest/v1/projects.roles/create)

--- a/examples/v2/iam_custom_role/jinja/organization_custom_role.jinja
+++ b/examples/v2/iam_custom_role/jinja/organization_custom_role.jinja
@@ -1,0 +1,24 @@
+{#
+Copyright 2017 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+  resources:
+  - name: custom-role
+    type: gcp-types/iam-v1:organizations.roles
+    properties:
+      parent: organizations/{{ properties["organizationId"] }}
+      roleId: {{ properties["roleId"] }}
+      role:
+        title: {{ properties["title"] }}
+        description: {{ properties["description"] }}
+        stage: {{ properties["stage"] }}
+        includedPermissions: {{ properties["includedPermissions"] }}

--- a/examples/v2/iam_custom_role/jinja/organization_custom_role.jinja.schema
+++ b/examples/v2/iam_custom_role/jinja/organization_custom_role.jinja.schema
@@ -1,0 +1,49 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+info:
+  title: Cloud IAM Organization Level Custom Roles
+  description: Creates a custom role under the specified Organization ID.
+
+imports:
+  - path: organization_custom_role.jinja
+
+properties:
+  title:
+    type: string
+    default: "\"\""
+    description: The title of the custom role.
+
+  description:
+    type: string
+    default: "\"\""
+    description: A description of the custom role.
+
+  stage:
+    type: string
+    default: ALPHA
+    description: The current launch stage of the custom role.
+    enum:
+     - ALPHA
+     - BETA
+     - GA
+     - DEPRECATED
+     - DISABLED
+     - EAP
+
+  includedPermissions:
+    type: array
+    default: []
+    description: The permissions that this custom role includes.
+

--- a/examples/v2/iam_custom_role/jinja/organization_custom_role.yaml
+++ b/examples/v2/iam_custom_role/jinja/organization_custom_role.yaml
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 imports:
-- path: project_custom_role.jinja
+- path: organization_custom_role.jinja
 
 resources:
 - name: custom-role
-  type: project_custom_role.jinja
+  type: organization_custom_role.jinja
   properties:
-    roleId: aCustomRole
+    organizationId:
+    roleId: myCustomRole
     title: My Title
     description: My description.
     includedPermissions:


### PR DESCRIPTION
Also updated the examples to use iam permissions instead of bigquery ones.