### PR TITLE
Add logbook example missing containerImage property

### DIFF
--- a/examples/v2/nodejs/jinja/nodejs.jinja
+++ b/examples/v2/nodejs/jinja/nodejs.jinja
@@ -31,6 +31,7 @@ resources:
   properties:
     zone: {{ properties["zone"] }}
     dockerImage: gcr.io/deployment-manager-examples/nodejsservice
+    containerImage: container-vm-v20160217
     port: {{ APPLICATION_PORT }}
 
     # Define the variables that are exposed to container as env variables.

--- a/examples/v2/nodejs/python/nodejs.py
+++ b/examples/v2/nodejs/python/nodejs.py
@@ -38,6 +38,7 @@ def GenerateConfig(context):
       'properties': {
           'zone': context.properties['zone'],
           'dockerImage': 'gcr.io/deployment-manager-examples/nodejsservice',
+          'containerImage': 'container-vm-v20160217',
           'port': application_port,
           # Define the variables that are exposed to container as env variables.
           'dockerEnv': {


### PR DESCRIPTION
I was following [this](https://cloud.google.com/deployment-manager/docs/create-advanced-deployment) tutorial, and noticed the examples didn't work as the `containerImage` property in `container_instance_template.[py|jinja]` would not resolve correctly. This commit defines the property in `nodejs.jinja` - same way as for the backend instance.