### PR TITLE
Configure Shared VPC when creating a project

### DIFF
--- a/examples/v2/project_creation/README.md
+++ b/examples/v2/project_creation/README.md
@@ -86,8 +86,28 @@ project creation exclusively.**
     in your yaml config.
 3.  Create the project. If using the CLI:
 
-    gcloud deployment-manager deployments create YOUR_DEPLOYMENT_NAME
-    --config config.yaml
+
+    gcloud deployment-manager deployments create YOUR_DEPLOYMENT_NAME \
+        --config config.yaml
 
 **Note: Project names are globally unique, and cannot be reused. Make sure you
 have a good naming scheme before stamping out projects.**
+
+## Shared VPC
+
+This templates also allows you to configure the
+[Shared VPC](https://cloud.google.com/vpc/docs/shared-vpc) feature.
+
+For that, you need to add the following permission to the DM Service Account on
+the Organization node:
+
+*   'roles/compute.xpnAdmin'
+ *   Visible in the Cloud Console's IAM permissions in Compute Engine -> Compute Shared VPC Admin.
+
+You can then create 2 projects with the `config_shared_vpc.yaml` file. One of
+the projects will be the host of the Shared VPC, and the other one will be a
+service project. Edit the `config_shared_vpc.yaml` file with your own values
+and create the deployment:
+
+    gcloud deployment-manager deployments create YOUR_DEPLOYMENT_NAME \
+        --config config_shared_vpc.yaml

--- a/examples/v2/project_creation/config_shared_vpc.yaml
+++ b/examples/v2/project_creation/config_shared_vpc.yaml
@@ -1,0 +1,71 @@
+imports:
+- path: project.py
+
+resources:
+# CHANGEME: Name of the host project for the Shared VPC
+- name: HOST_PROJECT
+  type: project.py
+  properties:
+    # CHANGEME: Change this to your organization ID.
+    organization-id: "ORG_ID"
+    # CHANGEME: Change the following to your organization's billing account
+    billing-account-name: billingAccounts/BILLING_ACCOUNT_ID
+    # The apis to enable in the new project.
+    # To see the possible APIs, use gcloud CLI: gcloud service-management list
+    apis:
+    - compute.googleapis.com
+    - deploymentmanager.googleapis.com
+    - storage-component.googleapis.com
+    - monitoring.googleapis.com
+    - logging.googleapis.com
+    # Makes the service account that Deployment Manager would use
+    # in the generated project an admin
+    set-dm-service-account-as-owner: true
+    # IAM policy on the new project
+    iam-policy:
+      bindings:
+      - role: roles/viewer
+        members:
+        # CHANGEME: Change this to your email address
+        - user:EMAIL
+      - role: roles/compute.networkUser
+        members:
+        # CHANGEME: Change this to your email address
+        - user:EMAIL
+      - role: roles/deploymentmanager.editor
+        members:
+        # CHANGEME: Change this to your email address
+        - user:EMAIL
+    shared_vpc_host: true
+# CHANGEME: Name of the service project for the Shared VPC
+- name: SERVICE_PROJECT
+  type: project.py
+  properties:
+    # CHANGEME: Change this to your organization ID.
+    organization-id: "ORG_ID"
+    # CHANGEME: Change the following to your organization's billing account
+    billing-account-name: billingAccounts/BILLING_ACCOUNT_ID
+    # The apis to enable in the new project.
+    # To see the possible APIs, use gcloud CLI: gcloud service-management list
+    apis:
+    - compute.googleapis.com
+    - deploymentmanager.googleapis.com
+    - storage-component.googleapis.com
+    - monitoring.googleapis.com
+    - logging.googleapis.com
+    # Makes the service account that Deployment Manager would use
+    # in the generated project an admin
+    set-dm-service-account-as-owner: true
+    # IAM policy on the new project
+    iam-policy:
+      bindings:
+      - role: roles/editor
+        members:
+        # CHANGEME: Change this to your email address
+        - user:EMAIL
+      - role: roles/compute.admin
+        members:
+        # CHANGEME: Change this to your email address
+        - user:EMAIL
+    # CHANGEME: Change this to the name of your host project for the Shared VPC
+    shared_vpc_service_of: HOST_PROJECT

--- a/examples/v2/project_creation/project.py.schema
+++ b/examples/v2/project_creation/project.py.schema
@@ -96,6 +96,7 @@ properties:
     properties:
       create-bucket:
         type: boolean
+        default: true
       bucket:
         type: string
   service-accounts:
@@ -105,6 +106,7 @@ properties:
     items:
       type: string
       pattern: ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$
+    default: []
   concurrent_api_activation:
     description: >
       Boolean flag if set to True activates all the requested APIs
@@ -115,3 +117,14 @@ properties:
       lot slower.
     type: boolean
     default: False
+  shared_vpc_host:
+    description: >
+      Whether you want this project to be host to a Shared VPC or not.
+    type: boolean
+    default: False
+  shared_vpc_service_of:
+    description: >
+      Must be a project ID configured to be host of a Shared VPC.
+      If used, this will enable this project as a service project for
+      the configured Shared VPC.
+    type: string


### PR DESCRIPTION
This adds the possibility to configure the Shared VPC when creating a project. A project can be the host of a Shared VPC or can be linked to another project to use its Shared VPC (it's then a "service project").

This adds a specific config file as example for this feature.

This also fixes a problem of resource name conflict