### PR TITLE
Add configs for GitHubSuite in google/resource-snippets folder

### DIFF
--- a/google/resource-snippets/cloudkms-v1/kms.jinja
+++ b/google/resource-snippets/cloudkms-v1/kms.jinja
@@ -1,0 +1,66 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- name: listLocations
+  action: gcp-types/cloudkms-v1:cloudkms.projects.locations.list
+  properties:
+    name: projects/{{ env["project"] }}
+  metadata:
+    runtimePolicy:
+    - CREATE
+- name: keyRing
+  type: gcp-types/cloudkms-v1:projects.locations.keyRings
+  properties:
+    parent: projects/{{ env["project"] }}/locations/{{ properties["region"] }}
+    keyRingId: test-{{ properties["time"] }}-keyRing
+- name: cryptoKey
+  type: gcp-types/cloudkms-v1:projects.locations.keyRings.cryptoKeys
+  properties:
+    parent: $(ref.keyRing.name)
+    cryptoKeyId: {{ env["deployment"] }}-cryptoKey
+    purpose: ENCRYPT_DECRYPT
+    labels:
+      foo: {{ env["deployment"] }}
+  accessControl:
+    gcpIamPolicy:
+      bindings:
+      - role: roles/cloudkms.admin
+        members:
+        - "user:{{ properties["user"] }}"
+{% if properties["create_crypto_key_version"] %}
+- name: crypto-key-version
+  type: gcp-types/cloudkms-v1:projects.locations.keyRings.cryptoKeys.cryptoKeyVersions
+  properties:
+    parent: $(ref.cryptoKey.name)
+{% endif %}
+- name: encrypt
+  action: gcp-types/cloudkms-v1:cloudkms.projects.locations.keyRings.cryptoKeys.encrypt
+  properties:
+    name: $(ref.cryptoKey.name)
+    # Base64 encoded plain text string
+    plaintext: $(ref.listLocations.toString().base64Encode())
+- name: decrypt
+  action: gcp-types/cloudkms-v1:cloudkms.projects.locations.keyRings.cryptoKeys.decrypt
+  properties:
+    name: $(ref.cryptoKey.name)
+    # Base64 encoded plain text string
+    ciphertext: $(ref.encrypt.ciphertext)
+- name: dummy
+  type: DUMMY_V1_RESOURCE
+  properties:
+    duration: 0,0
+    kind: $(ref.decrypt.plaintext.base64Decode().load().locations[0].name)
+    name: indirect-{{ env["deployment"] }}
+    project: {{ env["project"] }}

--- a/google/resource-snippets/cloudkms-v1/kms.yaml
+++ b/google/resource-snippets/cloudkms-v1/kms.yaml
@@ -1,0 +1,25 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+configVersion: v1alpha
+
+imports:
+- path: kms.jinja
+
+resources:
+- name: kms
+  type: kms.jinja
+  properties:
+    region: REGION_TO_RUN
+    user: ananke.iam@gmail.com

--- a/google/resource-snippets/dataproc-v1/README.md
+++ b/google/resource-snippets/dataproc-v1/README.md
@@ -1,0 +1,20 @@
+# Dataproc Example
+
+## Overview
+
+This is a [Google Cloud Deployment
+Manager](https://cloud.google.com/deployment-manager/overview) template that
+deploys a dataproc cluster.
+
+## Deploy the template
+
+Use `dataproc.yaml` to deploy this example template after changing
+REGION_TO_RUN and ZONE_TO_RUN.
+
+When ready, deploy with following command:
+
+    gcloud deployment-manager deployments create DEPLOYMENT_NAME --config dataproc.yaml
+
+## More information
+
+[Dataproc Documentation](https://cloud.google.com/dataproc/)

--- a/google/resource-snippets/dataproc-v1/dataproc.jinja
+++ b/google/resource-snippets/dataproc-v1/dataproc.jinja
@@ -1,0 +1,37 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#% description: Creates a Dataproc cluster.
+#% parameters:
+
+# Can't use deployment name as it is going to be filled in with a generated
+# name which has dashes in it, which are not valid bigquery name characters.
+{% set clusterName = (env["deployment"] + "-dataproc-cluster") %}
+
+resources:
+- name: {{ clusterName }}
+  type: gcp-types/dataproc-v1:projects.regions.clusters
+  properties:
+    region: {{ properties["region"] }}
+    projectId: {{ env["project"] }}
+    clusterName: {{ clusterName }}
+    config:
+      gceClusterConfig:
+        zoneUri: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}
+      masterConfig:
+        numInstances: 1
+        machineTypeUri: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/machineTypes/n1-standard-2
+      workerConfig:
+        numInstances: 2
+        machineTypeUri: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/machineTypes/n1-standard-2

--- a/google/resource-snippets/dataproc-v1/dataproc.yaml
+++ b/google/resource-snippets/dataproc-v1/dataproc.yaml
@@ -1,0 +1,23 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: dataproc.jinja
+
+resources:
+- name: dataproc
+  type: dataproc.jinja
+  properties:
+    region: REGION_TO_RUN
+    zone: ZONE_TO_RUN

--- a/google/resource-snippets/logging-v2/configurable_logging.jinja
+++ b/google/resource-snippets/logging-v2/configurable_logging.jinja
@@ -1,0 +1,34 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+#- type: logging.v2.sink
+- type: gcp-types/logging-v2:projects.sinks
+  name: sink
+  properties:
+    sink: sink-{{ env['deployment'] }}
+    destination: pubsub.googleapis.com/$(ref.my-topic.name)
+    filter: {{ properties['filter'] }}
+    outputVersionFormat: V2
+#- type: logging.v2.metric
+- type: gcp-types/logging-v2:projects.metrics
+  name: metric
+  properties:
+    metric: metric-{{ env['deployment'] }}
+    filter: {{ properties['filter'] }}
+#- type: pubsub.v1.topic
+- type: gcp-types/pubsub-v1:projects.topics
+  name: my-topic
+  properties:
+    topic: {{ env["deployment"] }}

--- a/google/resource-snippets/logging-v2/configurable_logging.yaml
+++ b/google/resource-snippets/logging-v2/configurable_logging.yaml
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: configurable_logging.jinja
+
+resources:
+- name: loggy
+  type: configurable_logging.jinja
+  properties:
+    filter: severity >= ERROR

--- a/google/resource-snippets/logging-v2/logging.jinja
+++ b/google/resource-snippets/logging-v2/logging.jinja
@@ -1,0 +1,34 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+#type: logging.v2.sink
+- type: gcp-types/logging-v2:projects.sinks
+  name: my-sink
+  properties:
+    sink: sink-{{ env['deployment'] }}
+    destination: pubsub.googleapis.com/$(ref.my-topic.name)
+    filter: {{ properties['filter'] }}
+    outputVersionFormat: V2
+#type: logging.v2.metric
+- type: gcp-types/logging-v2:projects.metrics
+  name: my-metric
+  properties:
+    metric: metric-{{ env['deployment'] }}
+    filter: {{ properties['filter'] }}
+#type: pubsub.v1.topic
+- type: gcp-types/pubsub-v1:projects.topics
+  name: my-topic
+  properties:
+    topic: {{ env["deployment"] }}

--- a/google/resource-snippets/logging-v2/logging.yaml
+++ b/google/resource-snippets/logging-v2/logging.yaml
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: logging.jinja
+
+resources:
+- name: loggy
+  type: logging.jinja
+  properties:
+    filter: severity >= ERROR

--- a/google/resource-snippets/pubsub-v1/configurable_pubsub.jinja
+++ b/google/resource-snippets/pubsub-v1/configurable_pubsub.jinja
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: pubsub.jinja
+
+resources:
+- name: pubsub
+  type: pubsub.jinja
+  properties:
+    ackDeadlineSeconds: 4

--- a/google/resource-snippets/pubsub-v1/configurable_pubsub.yaml
+++ b/google/resource-snippets/pubsub-v1/configurable_pubsub.yaml
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: configurable_pubsub.jinja
+
+resources:
+- name: pubsub
+  type: configurable_pubsub.jinja
+  properties:
+    ackDeadlineSeconds: 4

--- a/google/resource-snippets/pubsub-v1/publish.yaml
+++ b/google/resource-snippets/pubsub-v1/publish.yaml
@@ -1,0 +1,24 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- name: YOUR_DEPLOYMENT_NAME
+  action: gcp-types/pubsub-v1:pubsub.projects.topics.publish
+  properties:
+    topic: projects/cloud-dm-testing/topics/do-not-delete-topic
+    messages:
+    - data: SG9sYSBtdW5kbyE=
+  metadata:
+    runtimePolicy:
+    - CREATE

--- a/google/resource-snippets/pubsub-v1/pubsub.jinja
+++ b/google/resource-snippets/pubsub-v1/pubsub.jinja
@@ -1,0 +1,29 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set topic = env['deployment'] + '-' + env['name'] + '-topic' %}
+{% set subscription = env['deployment'] + '-' + env['name'] + '-subscription' %}
+
+resources:
+- name: my-topic
+  #type: pubsub.v1.topic
+  type: gcp-types/pubsub-v1:projects.topics
+  properties:
+    topic: {{ topic }}
+- name: my-subscription
+  #type: pubsub.v1.subscription
+  type: gcp-types/pubsub-v1:projects.subscriptions
+  properties:
+    subscription: {{ subscription }}
+    topic: $(ref.my-topic.name)

--- a/google/resource-snippets/pubsub-v1/pubsub.yaml
+++ b/google/resource-snippets/pubsub-v1/pubsub.yaml
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: pubsub.jinja
+
+resources:
+- name: pubsub
+  type: pubsub.jinja
+  properties:
+    ackDeadlineSeconds: 4

--- a/google/resource-snippets/spanner-v1/spanner.jinja
+++ b/google/resource-snippets/spanner-v1/spanner.jinja
@@ -1,0 +1,26 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- name: {{ env["deployment"] }}
+  type: gcp-types/spanner-v1:projects.instances
+  properties:
+    parent: projects/{{ env["project"] }}
+    instanceId: anitalavalatina
+    instance:
+      config: projects/{{ env["project"] }}/instanceConfigs/regional-us-central1
+      displayName: Anita Lava La Tina
+      nodeCount: {{ properties["nodeCount"] }}
+      labels:
+        foo: bar

--- a/google/resource-snippets/spanner-v1/spanner.yaml
+++ b/google/resource-snippets/spanner-v1/spanner.yaml
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: spanner.jinja
+
+resources:
+- name: my-spanner
+  type: spanner.jinja
+  properties:
+    nodeCount: 1


### PR DESCRIPTION
This commit includes test data for following type providers:
1. cloudkms-v1
2. dataproc-v1
3. logging-v2
4. pubsub-v1
5. spanner-v1
