### PR TITLE
Migrate integration test config snippets for gcp types

### DIFF
--- a/google/resource-snippets/bigquery-v2/bigquery.jinja
+++ b/google/resource-snippets/bigquery-v2/bigquery.jinja
@@ -1,0 +1,36 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#% description: Creates a BigQuery dataset and table within the dataset.
+#% parameters:
+
+# Can't use deployment name as it is going to be filled in with a generated
+# name which has dashes in it, which are not valid bigquery name characters.
+{% set DATASET = (env["deployment"] + "-dataset")|replace("-","_") %}
+{% set TABLE = (env["deployment"] + "-table")|replace("-","_") %}
+
+resources:
+- name: {{ DATASET }}-test
+# type: bigquery.v2.dataset
+  type: gcp-types/bigquery-v2:datasets
+  properties:
+    datasetReference:
+      datasetId: {{ DATASET }}
+- name: {{ TABLE }}-test
+# type: bigquery.v2.table
+  type: gcp-types/bigquery-v2:tables
+  properties:
+    datasetId: $(ref.{{ DATASET }}-test.datasetReference.datasetId)
+    tableReference:
+      tableId: {{ TABLE }}

--- a/google/resource-snippets/bigquery-v2/bigquery.yaml
+++ b/google/resource-snippets/bigquery-v2/bigquery.yaml
@@ -1,0 +1,20 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: bigquery.jinja
+
+resources:
+- name: bigquery
+  type: bigquery.jinja

--- a/google/resource-snippets/bigtableadmin-v2/bigtable.jinja
+++ b/google/resource-snippets/bigtableadmin-v2/bigtable.jinja
@@ -1,0 +1,42 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set INSTANCE = env["deployment"] + "-instance" %}
+{% set CLUSTER = env["deployment"] + "-cluster" %}
+{% set CLUSTER2 = env["deployment"] + "-cluster2" %}
+{% set TABLE = env["deployment"] + "-table" %}
+
+resources:
+- name: {{ INSTANCE }}
+#  type: bigtableadmin.v2.instance
+  type: gcp-types/bigtableadmin-v2:projects.instances
+  properties:
+    parent: projects/{{ env["project"] }}
+    instanceId: {{ INSTANCE }}
+    clusters:
+      {{ CLUSTER }}:
+        defaultStorageType: HDD
+        location: projects/{{ env["project"] }}/locations/{{ properties["zone"] }}
+    instance:
+      displayName: {{ properties["displayName"] }}
+      type: DEVELOPMENT
+- name: {{ TABLE }}
+#  type: bigtableadmin.v2.instance.table
+  type: gcp-types/bigtableadmin-v2:projects.instances.tables
+  properties:
+    parent: $(ref.{{ INSTANCE }}.name)
+    tableId: {{ TABLE }}
+    table:
+      granularity: MILLIS
+      columnFamilies: {{ properties["columnFamilies"] }}

--- a/google/resource-snippets/bigtableadmin-v2/bigtable.yaml
+++ b/google/resource-snippets/bigtableadmin-v2/bigtable.yaml
@@ -1,0 +1,30 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: bigtable.jinja
+
+resources:
+- name: my-bigtable
+  type: bigtable.jinja
+  properties:
+    zone: us-central1-b
+    displayName: Sample BigTable template
+    columnFamilies:
+      col1:
+        gcRule:
+          maxNumVersions: 2
+      col2:
+        gcRule:
+          maxNumVersions: 2

--- a/google/resource-snippets/cloudbuild-v1/cloudbuild.jinja
+++ b/google/resource-snippets/cloudbuild-v1/cloudbuild.jinja
@@ -1,0 +1,34 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set IMAGE = "gcr.io/" + env["project"] + "/dm-integration-test-" + env["deployment"] %}
+
+resources:
+- name: build-{{ env["deployment"] }}
+  action: gcp-types/cloudbuild-v1:cloudbuild.projects.builds.create
+  properties:
+    source:
+      storageSource:
+        bucket: {{ properties["bucket"] }}
+        object: {{ properties["object"] }}
+    steps:
+    - name: gcr.io/cloud-builders/docker
+      args:
+      - build
+      - -t
+      - {{ IMAGE }}
+      - .
+    images:
+    - {{ IMAGE }}
+    timeout: {{ properties["timeout"] }}

--- a/google/resource-snippets/cloudbuild-v1/cloudbuild.yaml
+++ b/google/resource-snippets/cloudbuild-v1/cloudbuild.yaml
@@ -1,0 +1,26 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: cloudbuild.jinja
+
+resources:
+- name: build
+  type: cloudbuild.jinja
+  properties:
+    # This is the smoketest used by cloudbuild, we have been assured that it
+    # will stay publically accessible.
+    bucket: smoketest-gcs-source
+    object: repo.tgz
+    timeout: 600s

--- a/google/resource-snippets/cloudresourcemanager-v1/patch_iam_project.yaml
+++ b/google/resource-snippets/cloudresourcemanager-v1/patch_iam_project.yaml
@@ -1,0 +1,39 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- name: get-iam-policy
+  action: gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.getIamPolicy
+  properties:
+    resource: YOUR_PROJECT_NAME
+- name: add-iam-policy
+  action: gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.setIamPolicy
+  properties:
+    resource: YOUR_PROJECT_NAME
+    policy: $(ref.get-iam-policy)
+    gcpIamPolicyPatch:
+      add:
+      - role: roles/dataflow.serviceAgent
+        members:
+        - user:ananke.prober@gmail.com
+- name: remove-iam-policy
+  action: gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.setIamPolicy
+  properties:
+    resource: YOUR_PROJECT_NAME
+    policy: $(ref.add-iam-policy)
+    gcpIamPolicyPatch:
+      remove:
+      - role: roles/dataflow.serviceAgent
+        members:
+        - user:ananke.prober@gmail.com

--- a/google/resource-snippets/cloudresourcemanager-v1/project.jinja
+++ b/google/resource-snippets/cloudresourcemanager-v1/project.jinja
@@ -1,0 +1,28 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set PROJECT_ID = "dm-integ-test-" + env["deployment"] %}
+
+resources:
+# Note that the name of the resource has no bearing on the created project, rather the property
+# 'projectId' is the important value. It is being kept the same in this test so that it is easier to
+# read the logs, which contain the resource name more often than its properties.
+- name: {{ PROJECT_ID }}
+# type: cloudresourcemanager.v1.project
+  type: gcp-types/cloudresourcemanager-v1:projects
+  properties:
+    projectId: {{ PROJECT_ID }}
+    parent:
+      type: organization
+      id: {{ properties["orgnizationId"] }}

--- a/google/resource-snippets/cloudresourcemanager-v1/project.yaml
+++ b/google/resource-snippets/cloudresourcemanager-v1/project.yaml
@@ -1,0 +1,22 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: project.jinja
+
+resources:
+- name: project
+  type: project.jinja
+  properties:
+    orgnizationId: ORGNIZATION_ID

--- a/google/resource-snippets/dns-v1/managed-zone.yaml
+++ b/google/resource-snippets/dns-v1/managed-zone.yaml
@@ -1,0 +1,22 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- name: YOUR_DEPLOYMENT_NAME
+# type: dns.v1.managedZone
+  type: gcp-types/dns-v1:managedZones
+  properties:
+    description: A managed zone
+# Making dnsName unique with deployment name for testing purpose.
+    dnsName: my-great-domain-YOUR_DEPLOYMENT_NAME.com.

--- a/google/resource-snippets/runtimeconfig-v1beta1/configurable_runtimeconfig.jinja
+++ b/google/resource-snippets/runtimeconfig-v1beta1/configurable_runtimeconfig.jinja
@@ -1,0 +1,49 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set CONFIG_NAME = env['deployment'] + '-' + properties['config'] %}
+{% set VARIABLE_PREFIX = properties['variablePath'] %}
+
+resources:
+#- type: runtimeconfig.v1beta1.config
+- type: gcp-types/runtimeconfig-v1beta1:projects.configs
+  name: {{ CONFIG_NAME }}
+  properties:
+    config: {{ CONFIG_NAME }}
+    description: {{ properties['description'] }}
+#- type: runtimeconfig.v1beta1.variable
+- type: gcp-types/runtimeconfig-v1beta1:projects.configs.variables
+  name: my-variable1
+  properties:
+    parent: $(ref.{{ CONFIG_NAME }}.name)
+    variable: {{ VARIABLE_PREFIX }}/{{ properties['variable1'] }}
+    value: {{ properties['value1'] }}
+#- type: runtimeconfig.v1beta1.variable
+- type: gcp-types/runtimeconfig-v1beta1:projects.configs.variables
+  name: my-variable2
+  properties:
+    parent: $(ref.{{ CONFIG_NAME }}.name)
+    variable: {{ VARIABLE_PREFIX }}/{{ properties['variable2'] }}
+    value: {{ properties['value2'] }}
+#- type: runtimeconfig.v1beta1.waiter
+- type: gcp-types/runtimeconfig-v1beta1:projects.configs.waiters
+  name: my-waiter
+  properties:
+    parent: $(ref.{{ CONFIG_NAME }}.name)
+    waiter: {{ properties['waiter'] }}
+    timeout: {{ properties['timeout'] }}
+    success:
+      cardinality:
+        path: {{ VARIABLE_PREFIX }}
+        number: {{ properties['number'] }}

--- a/google/resource-snippets/runtimeconfig-v1beta1/configurable_runtimeconfig.yaml
+++ b/google/resource-snippets/runtimeconfig-v1beta1/configurable_runtimeconfig.yaml
@@ -1,0 +1,31 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: configurable_runtimeconfig.jinja
+
+resources:
+- name: runtimeconfigtest
+  type: configurable_runtimeconfig.jinja
+  properties:
+    config: cfg
+    description: Karen's config
+    variablePath: prefix
+    variable1: v1
+    value1: b3Jhbmdl
+    variable2: v2
+    value2: b3Jh
+    waiter: w1
+    timeout: 200.000s
+    number: 2

--- a/google/resource-snippets/runtimeconfig-v1beta1/runtimeconfig.jinja
+++ b/google/resource-snippets/runtimeconfig-v1beta1/runtimeconfig.jinja
@@ -1,0 +1,49 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set CONFIG_NAME = 'config-' + env['deployment'] %}
+{% set VARIABLE_PREFIX = properties['variablePath'] %}
+
+resources:
+#- type: runtimeconfig.v1beta1.config
+- type: gcp-types/runtimeconfig-v1beta1:projects.configs
+  name: {{ CONFIG_NAME }}
+  properties:
+    config: {{ CONFIG_NAME }}
+    description: {{ properties['description'] }}
+#- type: runtimeconfig.v1beta1.variable
+- type: gcp-types/runtimeconfig-v1beta1:projects.configs.variables
+  name: my-variable1
+  properties:
+    parent: $(ref.{{ CONFIG_NAME }}.name)
+    variable: {{ VARIABLE_PREFIX }}/{{ properties['variable1'] }}
+    value: {{ properties['value1'] }}
+#- type: runtimeconfig.v1beta1.variable
+- type: gcp-types/runtimeconfig-v1beta1:projects.configs.variables
+  name: my-variable2
+  properties:
+    parent: $(ref.{{ CONFIG_NAME }}.name)
+    variable: {{ VARIABLE_PREFIX }}/{{ properties['variable2'] }}
+    value: {{ properties['value2'] }}
+#- type: runtimeconfig.v1beta1.waiter
+- type: gcp-types/runtimeconfig-v1beta1:projects.configs.waiters
+  name: my-waiter
+  properties:
+    parent: $(ref.{{ CONFIG_NAME }}.name)
+    waiter: test-waiter
+    timeout: {{ properties['timeout'] }}
+    success:
+      cardinality:
+        path: {{ VARIABLE_PREFIX }}
+        number: {{ properties['number'] }}

--- a/google/resource-snippets/runtimeconfig-v1beta1/runtimeconfig.yaml
+++ b/google/resource-snippets/runtimeconfig-v1beta1/runtimeconfig.yaml
@@ -1,0 +1,30 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: runtimeconfig.jinja
+
+resources:
+- type: runtimeconfig.jinja
+  name: my-config
+  properties:
+    config: my-config
+    description: change description
+    variablePath: prefix
+    variable1: v1
+    value1: b3Jhbmdl
+    variable2: shade3
+    value2: b4Jh
+    timeout: 200.000s
+    number: 2

--- a/google/resource-snippets/servicemanagement-v1/enable.jinja
+++ b/google/resource-snippets/servicemanagement-v1/enable.jinja
@@ -1,0 +1,25 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- name: {{ env['deployment'] }}-enable
+  type: deploymentmanager.v2.virtual.enableService
+  properties:
+    consumerId: "project:{{ env['project'] }}"
+    serviceName: drive
+- name: {{ env['deployment'] }}-enable-other
+  action: gcp-types/servicemanagement-v1:servicemanagement.services.enable
+  properties:
+    consumerId: "project:{{ env['project'] }}"
+    serviceName: bigtableadmin.googleapis.com

--- a/google/resource-snippets/servicemanagement-v1/enable.yaml
+++ b/google/resource-snippets/servicemanagement-v1/enable.yaml
@@ -1,0 +1,20 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: enable.jinja
+
+resources:
+- name: enable
+  type: enable.jinja

--- a/google/resource-snippets/sqladmin-v1beta4/cloudsql.jinja
+++ b/google/resource-snippets/sqladmin-v1beta4/cloudsql.jinja
@@ -1,0 +1,48 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set instanceName = env['deployment'] + '-instance' %}
+# DB cannot have things like dashes, so must be simple. It is unique to the
+# instance so is fine in this form.
+{% set dbName = env['deployment'] + 'mydb' %}
+{% set certName = env['deployment'] + '-sslcert' %}
+
+resources:
+- name: {{ instanceName }}
+#  type: sqladmin.v1beta4.instance
+  type: gcp-types/sqladmin-v1beta4:instances
+  properties:
+    settings:
+      tier: {{ properties['tier'] }}
+- name: {{ dbName }}
+#  type: sqladmin.v1beta4.database
+  type: gcp-types/sqladmin-v1beta4:databases
+  properties:
+    name: {{ dbName }}
+    instance: $(ref.{{ instanceName }}.name)
+  {% if properties['charset'] == 'utf8' %}
+    charset: utf8
+    collation: utf8_general_ci
+  {% else %}
+    charset: latin1
+    collation: latin1_swedish_ci
+  {% endif %}
+- name: {{ certName }}
+#  type: sqladmin.v1beta4.sslCert
+  type: gcp-types/sqladmin-v1beta4:sslCerts
+  metadata:
+    dependsOn:
+    - {{ dbName }}
+  properties:
+    instance: $(ref.{{ instanceName }}.name)

--- a/google/resource-snippets/sqladmin-v1beta4/cloudsql.yaml
+++ b/google/resource-snippets/sqladmin-v1beta4/cloudsql.yaml
@@ -1,0 +1,23 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: cloudsql.jinja
+
+resources:
+- name: cloudsql
+  type: cloudsql.jinja
+  properties:
+    tier: D1
+    charset: utf8

--- a/google/resource-snippets/sqladmin-v1beta4/cloudsql_with_user.jinja
+++ b/google/resource-snippets/sqladmin-v1beta4/cloudsql_with_user.jinja
@@ -1,0 +1,45 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set instanceName = env['deployment'] + '-instance' %}
+# DB cannot have things like dashes, so must be simple. It is unique to the
+# instance so is fine in this form.
+{% set dbName = 'mydb' %}
+{% set userName = 'testuser' %}
+
+resources:
+- name: {{ instanceName }}
+#  type: sqladmin.v1beta4.instance
+  type: gcp-types/sqladmin-v1beta4:instances
+  properties:
+    settings:
+      tier: {{ properties['tier'] }}
+- name: {{ dbName }}
+#  type: sqladmin.v1beta4.database
+  type: gcp-types/sqladmin-v1beta4:databases
+  properties:
+    name: {{ dbName }}
+    instance: $(ref.{{ instanceName }}.name)
+    charset: {{ properties['charset'] }}
+- name: {{ userName }}
+#  type: sqladmin.v1beta4.user
+  type: gcp-types/sqladmin-v1beta4:users
+  metadata:
+    dependsOn:
+      - {{ dbName }}
+  properties:
+    name: {{ userName }}
+    instance: $(ref.{{ instanceName }}.name)
+    host: {{ properties['hostName'] }}
+    password: {{ properties['password'] }}

--- a/google/resource-snippets/sqladmin-v1beta4/cloudsql_with_user.yaml
+++ b/google/resource-snippets/sqladmin-v1beta4/cloudsql_with_user.yaml
@@ -1,0 +1,25 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: cloudsql_with_user.jinja
+
+resources:
+- name: cloudsql_with_user
+  type: cloudsql_with_user.jinja
+  properties:
+    tier: D1
+    charset: utf8
+    password: testpass
+    hostName: testhost

--- a/google/resource-snippets/storage-v1/bucket.jinja
+++ b/google/resource-snippets/storage-v1/bucket.jinja
@@ -1,0 +1,75 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set LOGBUCKET = "log-bucket-" + env["deployment"]  %}
+
+resources:
+#- type: storage.v1.bucket
+- type: gcp-types/storage-v1:buckets
+  name: {{ LOGBUCKET }}
+  properties:
+    predefinedAcl: projectPrivate
+    projection: full
+    location: US
+    storageClass: STANDARD
+#- type: storage.v1.bucket
+- type: gcp-types/storage-v1:buckets
+  name: bucket-{{ env["deployment"] }}
+  properties:
+    predefinedAcl: projectPrivate
+    projection: full
+    location: US
+    storageClass: STANDARD
+    defaultObjectAcl:
+      - bucket: bucket-{{ env["deployment"] }}
+        domain: www.google.com
+        email: scoobydoo@google.com
+        # 657686986194 is the number for project ccit-testing
+        entity: project-editors-657686986194
+        role: READER
+        projectTeam:
+          team: editors
+          projectNumber: 657686986194
+    cors:
+      - maxAgeSeconds: 10
+        method:
+          - GET
+          - POST
+          - OPTIONS
+        origin:
+          - '*'
+        responseHeader:
+          - Content-Type
+          - Last-Modified
+          - Expires
+    lifecycle:
+      rule:
+        - action:
+            type: Delete
+          condition:
+            age: 30
+            isLive: true
+        - action:
+            type: Delete
+          condition:
+            isLive: false
+            numNewerVersions: 3
+    logging:
+      logBucket: $(ref.{{ LOGBUCKET }}.name)
+      logObjectPrefix: log-prefix
+    versioning:
+      enabled: true
+    website:
+      mainPageSuffix: http://www.google.com/
+      notFoundpage: http://www.google.com/not-found

--- a/google/resource-snippets/storage-v1/bucket.yaml
+++ b/google/resource-snippets/storage-v1/bucket.yaml
@@ -1,0 +1,20 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: bucket.jinja
+
+resources:
+- name: bucket
+  type: bucket.jinja

--- a/google/resource-snippets/storage-v1/bucket_acl.jinja
+++ b/google/resource-snippets/storage-v1/bucket_acl.jinja
@@ -1,0 +1,37 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% set BUCKETNAME = "bucket-" + env["deployment"]  %}
+
+resources:
+#- type: storage.v1.bucket
+- type: gcp-types/storage-v1:buckets
+  name: {{ BUCKETNAME }}
+  properties:
+    predefinedAcl: projectPrivate
+    projection: full
+    location: US
+    storageClass: STANDARD
+#- type: storage.v1.bucketAccessControl
+- type: gcp-types/storage-v1:bucketAccessControls
+  name: test-bucket-acl
+  properties:
+    bucket: $(ref.{{ BUCKETNAME }}.name)
+    domain: www.google.com
+    email: scoobydoo@google.com
+    entity: project-editors-657686986194
+    projectTeam:
+      projectNumber: 657686986194
+      team: editors
+    role: OWNER

--- a/google/resource-snippets/storage-v1/bucket_acl.yaml
+++ b/google/resource-snippets/storage-v1/bucket_acl.yaml
@@ -1,0 +1,20 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: bucket_acl.jinja
+
+resources:
+- name: bucket_acl
+  type: bucket_acl.jinja


### PR DESCRIPTION
This pull request migrates snippets for following types:

1. gcp-types/dns-v1
2. gcp-types/bigquery-v2
3. gcp-types/runtimeconfig-v1beta1
4. gcp-types/cloudbuild-v1
5. gcp-types/cloudresourcemanager-v1
6. gcp-types/servicemanagement-v1
7. gcp-types/sqladmin-v1beta4
8. gcp-types/storage-v1
9. gcp-types/bigtableadmin-v2