### PR TITLE
Fix JSON schema for `project.py` template

### DIFF
--- a/examples/v2/project_creation/project.py.schema
+++ b/examples/v2/project_creation/project.py.schema
@@ -55,34 +55,30 @@ properties:
       will automatically add/merge in the service account making the project
       as an owner.
     type: object
-    items:
-      required:
-      - bindings
-      properties:
-        bindings:
-          description: >
-            Bindings of members to roles.
-          type: array
-          item:
-            description: >
-              A set of members bound to a particular role.
-            type: object
-            item:
-              required:
-              - role
-              - members
-              role:
-                description: >
-                  The role that all the members will receive.
+    required:
+    - bindings
+    properties:
+      bindings:
+        description: Bindings of members to roles.
+        type: array
+        items:
+          description: A set of members bound to a particular role.
+          type: object
+          required:
+          - role
+          - members
+          properties:
+            role:
+              description: The role that all the members will receive.
+              type: string
+              pattern: ^roles/
+            members:
+              decription: >
+                The members that will be given the permissions in role.
+              type: array
+              items:
                 type: string
-                pattern: ^roles/
-              members:
-                decription: >
-                  The members that will be given the permissions in role.
-                type: array
-                item:
-                  type: string
-                  pattern: "^(user|group|domain|serviceAccount):"
+                pattern: "^(user|group|domain|serviceAccount):"
   set-dm-service-account-as-owner:
     description: >
       If set to true, the service account that Deployment Manager will use in


### PR DESCRIPTION
The current JSON schema for the `project.py` template is not statically valid.

This is intended to fix the JSON syntax as well as fix the validation the `iam-policy` section of the config.

### Example of Failure

The following config will succeed in being validated and only when the upstream resource complains of the invalid fields will the deploy fail.

```
imports:
- path: project.py

resources:
- name: test-project
  type: project.py
  properties:
...
    iam-policy:
      bindings:
      - role: not-a-valid-role
        members:
        - nobody@email.address.net
```

resulting in the following error when it is deployed:

```
ERROR: (gcloud.deployment-manager.deployments.update) Error in Operation [operation-000...]: errors:
- code: RESOURCE_ERROR
  location: /deployments/deploy-name/resources/test-project
  message: '{"ResourceType":"cloudresourcemanager.v1.project","ResourceErrorCode":"400","ResourceErrorMessage":{"code":400,"message":"Request
    contains an invalid argument.","status":"INVALID_ARGUMENT","statusMessage":"Bad
    Request","requestPath":"https://cloudresourcemanager.googleapis.com/v1/projects/test-project:setIamPolicy","httpMethod":"POST"}}'
```

With the changes in this PR, the following deploy would have failed during manifest expansion:

```
ERROR: (gcloud.deployment-manager.deployments.update) Error in Operation [operation-000...]: errors:
- code: MANIFEST_EXPANSION_USER_ERROR
  message: |
    Manifest expansion encountered the following errors: Invalid properties for 'project.py':
    'nobody@email.address.net' does not match '^(user|group|domain|serviceAccount):' at ['iam-policy', 'bindings', 2, 'members', 0]
...
```
