### PR TITLE
Fix project reference syntax error in project creation example

### DIFF
--- a/examples/v2/project_creation/project.py
+++ b/examples/v2/project_creation/project.py
@@ -96,7 +96,7 @@ def GenerateConfig(context):
       policies_to_add.append({
         'role': 'roles/owner',
         'member': [
-          'serviceAccount:${ref.' + project_id + '.projectNumber)@cloudservices.gserviceaccount.com'
+          'serviceAccount:$(ref.' + project_id + '.projectNumber)@cloudservices.gserviceaccount.com'
         ]
       })
 


### PR DESCRIPTION
Looks like a typo.  Nothing big.