### PR TITLE
Fix the image name from deprecated container_vm to cos. 

### DIFF
--- a/examples/v2/common/jinja/container_instance_template.jinja
+++ b/examples/v2/common/jinja/container_instance_template.jinja
@@ -32,7 +32,7 @@ resources:
         mode: READ_WRITE
         type: PERSISTENT
         initializeParams:
-          sourceImage: https://www.googleapis.com/compute/v1/projects/google-containers/global/images/{{ properties['containerImage'] }}
+          sourceImage: https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/{{ properties['containerImage'] }}
       networkInterfaces:
       - accessConfigs:
         - name: external-nat

--- a/examples/v2/common/jinja/container_vm.jinja
+++ b/examples/v2/common/jinja/container_vm.jinja
@@ -32,7 +32,7 @@ resources:
       boot: true
       initializeParams:
         diskName: {{ env['name'] }}-disk
-        sourceImage: {{ COMPUTE_URL_BASE }}projects/google-containers/global/images/{{ properties['containerImage'] }}
+        sourceImage: {{ COMPUTE_URL_BASE }}projects/cos-cloud/global/images/{{ properties['containerImage'] }}
     networkInterfaces:
     - accessConfigs:
       - name: external-nat

--- a/examples/v2/common/python/container_instance_template.py
+++ b/examples/v2/common/python/container_instance_template.py
@@ -21,7 +21,7 @@ def GenerateConfig(context):
   """Generates configuration."""
 
   image = ''.join(['https://www.googleapis.com/compute/v1/',
-                   'projects/google-containers/global/images/',
+                   'projects/cos-cloud/global/images/',
                    context.properties['containerImage']])
   default_network = ''.join(['https://www.googleapis.com/compute/v1/projects/',
                              context.env['project'],

--- a/examples/v2/container_igm/jinja/container_igm.jinja
+++ b/examples/v2/container_igm/jinja/container_igm.jinja
@@ -42,7 +42,7 @@ resources:
         boot: true
         autoDelete: true
         initializeParams:
-          sourceImage: https://www.googleapis.com/compute/v1/projects/google-containers/global/images/{{ properties["containerImage"] }}
+          sourceImage: https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/{{ properties["containerImage"] }}
       machineType: {{ properties["machineType"] }}
       networkInterfaces:
       - network: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/global/networks/default

--- a/examples/v2/container_igm/jinja/container_igm.yaml
+++ b/examples/v2/container_igm/jinja/container_igm.yaml
@@ -20,7 +20,7 @@ resources:
   type: container_igm.jinja
   properties:
     zone: us-central1-f
-    containerImage: family/container-vm
+    containerImage: family/cos-stable
     containerManifest: container_manifest.yaml
     targetSize: 2
     maxReplicas: 5

--- a/examples/v2/container_igm/python/container_igm.py
+++ b/examples/v2/container_igm/python/container_igm.py
@@ -20,7 +20,7 @@ def GenerateConfig(context):
   instance_template = context.env['deployment'] + '-it'
   igm = context.env['deployment'] + '-igm'
   image = ''.join(['https://www.googleapis.com/compute/v1/',
-                   'projects/google-containers/global/images/',
+                   'projects/cos-cloud/global/images/',
                    context.properties['containerImage']])
   default_network = ''.join(['https://www.googleapis.com/compute/v1/projects/',
                              context.env['project'],

--- a/examples/v2/container_igm/python/container_igm.yaml
+++ b/examples/v2/container_igm/python/container_igm.yaml
@@ -20,7 +20,7 @@ resources:
   type: container_igm.py
   properties:
     zone: us-central1-f
-    containerImage: family/container-vm
+    containerImage: family/cos-stable
     containerManifest: container_manifest.yaml
     targetSize: 2
     maxReplicas: 5

--- a/examples/v2/container_vm/jinja/container_vm.yaml
+++ b/examples/v2/container_vm/jinja/container_vm.yaml
@@ -22,5 +22,5 @@ resources:
     type: container_vm.jinja
     properties:
       zone: ZONE_TO_RUN
-      containerImage: family/container-vm
+      containerImage: family/cos-stable
       containerManifest: container_manifest

--- a/examples/v2/container_vm/python/container_vm.yaml
+++ b/examples/v2/container_vm/python/container_vm.yaml
@@ -22,5 +22,5 @@ resources:
     type: container_vm.py
     properties:
       zone: ZONE_TO_RUN
-      containerImage: family/container-vm
+      containerImage: family/cos-stable
       containerManifest: container_manifest

--- a/examples/v2/ha-service/container_instance_template.py
+++ b/examples/v2/ha-service/container_instance_template.py
@@ -21,7 +21,7 @@ def GenerateConfig(context):
   """Generates config."""
 
   image = ''.join(['https://www.googleapis.com/compute/v1/',
-                   'projects/google-containers/global/images/',
+                   'projects/cos-cloud/global/images/',
                    context.properties['containerImage']])
   default_network = ''.join(['https://www.googleapis.com/compute/v1/projects/',
                              context.env['project'],

--- a/examples/v2/ha-service/jinja/service.jinja.schema
+++ b/examples/v2/ha-service/jinja/service.jinja.schema
@@ -34,7 +34,7 @@ properties:
   containerImage:
     type: string
     description: Container VM image name to run on VMs.
-    default: container-vm-v20160217
+    default: family/cos-stable
   dockerImage:
     type: string
     description: Container image to run on VMs.

--- a/examples/v2/ha-service/python/service.py.schema
+++ b/examples/v2/ha-service/python/service.py.schema
@@ -34,7 +34,7 @@ properties:
   containerImage:
     type: string
     description: Container VM image name to run on VMs.
-    default: container-vm-v20160217
+    default: family/cos-stable
   dockerImage:
     type: string
     description: Container image to run on VMs.

--- a/examples/v2/ha-service/service.py.schema
+++ b/examples/v2/ha-service/service.py.schema
@@ -34,7 +34,7 @@ properties:
   containerImage:
     type: string
     description: Container VM image name to run on VMs.
-    default: container-vm-v20151215
+    default: family/cos-stable
   dockerImage:
     type: string
     description: Container image to run on VMs.

--- a/examples/v2/nodejs/jinja/frontend.jinja.schema
+++ b/examples/v2/nodejs/jinja/frontend.jinja.schema
@@ -46,7 +46,7 @@ properties:
 
   containerImage:
     type: string
-    default: container-vm-v20160217
+    default: family/cos-stable
     description: The container image to be used
 
   size:

--- a/examples/v2/nodejs/jinja/nodejs.jinja
+++ b/examples/v2/nodejs/jinja/nodejs.jinja
@@ -23,7 +23,7 @@ resources:
   properties:
     zone: {{ properties["zone"] }}
     dockerImage: gcr.io/deployment-manager-examples/mysql
-    containerImage: container-vm-v20160217
+    containerImage: family/cos-stable
     port: {{ MYSQL_PORT }}
 
 - name: {{ FRONTEND }}

--- a/examples/v2/nodejs/python/frontend.py.schema
+++ b/examples/v2/nodejs/python/frontend.py.schema
@@ -46,7 +46,7 @@ properties:
 
   containerImage:
     type: string
-    default: container-vm-v20160217
+    default: family/cos-stable
     description: The container image to be used
 
   size:

--- a/examples/v2/nodejs/python/nodejs.py
+++ b/examples/v2/nodejs/python/nodejs.py
@@ -29,7 +29,7 @@ def GenerateConfig(context):
       'properties': {
           'zone': context.properties['zone'],
           'dockerImage': 'gcr.io/deployment-manager-examples/mysql',
-          'containerImage': 'container-vm-v20160217',
+          'containerImage': 'family/cos-stable',
           'port': mysql_port
       }
   }, {

--- a/examples/v2/nodejs_l7/jinja/application.jinja
+++ b/examples/v2/nodejs_l7/jinja/application.jinja
@@ -20,7 +20,7 @@ limitations under the License.
 {% set LB_PORT = 8080 %}
 {% set MYSQL_PORT = 8080 %}
 
-{% set CONTAINER_IMAGE = "container-vm-v20151103" %}
+{% set CONTAINER_IMAGE = "family/cos-stable" %}
 
 resources:
 - name: {{ BACKEND }}

--- a/examples/v2/nodejs_l7/jinja/service.jinja.schema
+++ b/examples/v2/nodejs_l7/jinja/service.jinja.schema
@@ -48,7 +48,7 @@ properties:
 
   containerImage:
     type: string
-    default: container-vm-v20160217
+    default: family/cos-stable
     description: The container image to be used
 
   dockerEnv:

--- a/examples/v2/nodejs_l7/python/application.py
+++ b/examples/v2/nodejs_l7/python/application.py
@@ -24,7 +24,7 @@ def GenerateConfig(context):
   static_service = context.env['deployment'] + '-static-service'
   application = context.env['deployment'] + '-application'
 
-  container_image = 'container-vm-v20160217'
+  container_image = 'family/cos-stable'
 
   application_port = 8080
   lb_port = 8080

--- a/examples/v2/nodejs_l7/python/service.py.schema
+++ b/examples/v2/nodejs_l7/python/service.py.schema
@@ -48,7 +48,7 @@ properties:
 
   containerImage:
     type: string
-    default: container-vm-v20160217
+    default: family/cos-stable
     description: The container image to be used
 
   dockerEnv:

--- a/google/resource-snippets/container-v1/gke_provider_cluster.jinja.schema
+++ b/google/resource-snippets/container-v1/gke_provider_cluster.jinja.schema
@@ -28,7 +28,7 @@ properties:
     - v1beta1
   imageType:
     type: string
-    description: Image type of the cluster's node pool (cos or container-vm)
+    description: Image type of the cluster's node pool (cos or ubuntu)
     default: cos
     enum:
     - cos

--- a/templates/container_instance.py.schema
+++ b/templates/container_instance.py.schema
@@ -35,7 +35,7 @@ properties:
   containerImage:
     description: Name of the Google Cloud Container VM Image
     type: string
-    default: container-vm-v20151103
+    default: family/cos-stable
   dockerImage:
     description: String containing the docker image to instantiate
     type: string

--- a/tools/genconfig/example/generated.jinja
+++ b/tools/genconfig/example/generated.jinja
@@ -8,7 +8,7 @@ resources:
         boot: true
         deviceName: boot
         initializeParams:
-          sourceImage: https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20151215
+          sourceImage: https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/family/cos-stable
         mode: READ_WRITE
         type: PERSISTENT
       machineType: f1-micro


### PR DESCRIPTION
Also replace actual images by family names, which is much more useful and will always point to the current released image.