### PR TITLE
fixes for nodejs_l7 python example due to google_containers project deprecated to cos-cloud

### DIFF
--- a/examples/v2/common/python/container_helper.py
+++ b/examples/v2/common/python/container_helper.py
@@ -36,11 +36,11 @@ def GenerateManifest(context):
       'apiVersion': 'v1',
       'kind': 'Pod',
       'metadata': {
-          'name': context.env['name']
+          'name': str(context.env['name'])
           },
       'spec': {
           'containers': [{
-              'name': context.env['name'],
+              'name': str(context.env['name']),
               'image': context.properties['dockerImage'],
               'ports': [{
                   'hostPort': context.properties['port'],

--- a/examples/v2/common/python/container_instance_template.py
+++ b/examples/v2/common/python/container_instance_template.py
@@ -34,7 +34,7 @@ def GenerateConfig(context):
           'properties': {
               'metadata': {
                   'items': [{
-                      'key': 'google-container-manifest',
+                      'key': 'gce-container-declaration',
                       'value': GenerateManifest(context)
                       }]
                   },
@@ -53,7 +53,11 @@ def GenerateConfig(context):
                       'type': 'ONE_TO_ONE_NAT'
                       }],
                   'network': default_network
-                  }]
+                  }],
+                'serviceAccounts': [{
+                    'email': 'default',
+                    'scopes': ['https://www.googleapis.com/auth/logging.write']
+                    }]
               }
           }
       }

--- a/examples/v2/common/python/container_vm.py
+++ b/examples/v2/common/python/container_vm.py
@@ -44,7 +44,7 @@ def GenerateConfig(context):
                                      'f1-micro'),
       'metadata': {
           'items': [{
-              'key': 'google-container-manifest',
+              'key': 'gce-container-declaration',
               'value': GenerateManifest(context)
               }]
           },
@@ -55,7 +55,7 @@ def GenerateConfig(context):
           'boot': True,
           'initializeParams': {
               'diskName': base_name + '-disk',
-              'sourceImage': GlobalComputeUrl('google-containers',
+              'sourceImage': GlobalComputeUrl('cos-cloud',
                                               'images',
                                               context.properties[
                                                   'containerImage'])
@@ -69,7 +69,11 @@ def GenerateConfig(context):
           'network': GlobalComputeUrl(context.env['project'],
                                       'networks',
                                       'default')
-          }]
+          }],
+        'serviceAccounts': [{
+            'email': 'default',
+            'scopes': ['https://www.googleapis.com/auth/logging.write']
+            }]
       }
 
   # Resources to return.


### PR DESCRIPTION


- change project from google_containers to cos-cloud
- change the key to 'gce-container-declaration' for the container manifest
- add service account default with scope logging.write to the instances
- fix the Pod and container name by casting the unicode value to string