### PR TITLE
Replacing reference to deprecated `google-containers` project with  `cos-cloud`.

### DIFF
--- a/examples/v2/common/jinja/container_vm.jinja
+++ b/examples/v2/common/jinja/container_vm.jinja
@@ -22,7 +22,7 @@ resources:
     machineType: {{ COMPUTE_URL_BASE }}projects/{{ env['project'] }}/zones/{{ properties['zone'] }}/machineTypes/f1-micro
     metadata:
       items:
-      - key: google-container-manifest
+      - key: gce-container-declaration
         value: |
           {{ GenerateManifest(env['name'], properties['port'], properties['dockerImage'], properties['dockerEnv'])|indent(10) }}
     disks:
@@ -38,3 +38,9 @@ resources:
       - name: external-nat
         type: ONE_TO_ONE_NAT
       network: {{ COMPUTE_URL_BASE }}projects/{{ env['project'] }}/global/networks/default
+    serviceAccounts:
+      - email: default
+        scopes:
+        - https://www.googleapis.com/auth/logging.write
+        - https://www.googleapis.com/auth/monitoring.write
+

--- a/examples/v2/container_vm/jinja/container_vm.jinja
+++ b/examples/v2/container_vm/jinja/container_vm.jinja
@@ -32,7 +32,7 @@ resources:
     machineType: {{ ZonalComputeUrl(env['project'], properties['zone'], 'machineTypes', 'n1-standard-1') }}
     metadata:
       items:
-        - key: google-container-manifest
+        - key: gce-container-declaration
           value: |
             {{ imports[properties['containerManifest']]|indent(12) }}
     disks:
@@ -48,5 +48,9 @@ resources:
           - name: external-nat
             type: ONE_TO_ONE_NAT
         network: {{ GlobalComputeUrl(env['project'],  'networks', 'default') }}
-
+    serviceAccounts:
+      - email: default
+        scopes:
+        - https://www.googleapis.com/auth/logging.write
+        - https://www.googleapis.com/auth/monitoring.write
 

--- a/examples/v2/container_vm/jinja/container_vm.jinja
+++ b/examples/v2/container_vm/jinja/container_vm.jinja
@@ -42,7 +42,7 @@ resources:
         boot: true
         initializeParams:
           diskName: {{ BASE_NAME }}-disk
-          sourceImage: {{ GlobalComputeUrl('google-containers', 'images', properties['containerImage']) }}
+          sourceImage: {{ GlobalComputeUrl('cos-cloud', 'images', properties['containerImage']) }}
     networkInterfaces:
       - accessConfigs:
           - name: external-nat

--- a/examples/v2/container_vm/python/container_vm.py
+++ b/examples/v2/container_vm/python/container_vm.py
@@ -56,7 +56,7 @@ def GenerateConfig(context):
           'boot': True,
           'initializeParams': {
               'diskName': base_name + '-disk',
-              'sourceImage': GlobalComputeUrl('google-containers',
+              'sourceImage': GlobalComputeUrl('cos-cloud',
                                               'images',
                                               context.properties[
                                                   'containerImage'])

--- a/examples/v2/container_vm/python/container_vm.py
+++ b/examples/v2/container_vm/python/container_vm.py
@@ -44,7 +44,7 @@ def GenerateConfig(context):
                                      'n1-standard-1'),
       'metadata': {
           'items': [{
-              'key': 'google-container-manifest',
+              'key': 'gce-container-declaration',
               'value': context.imports[
                   context.properties['containerManifest']],
               }]
@@ -70,6 +70,13 @@ def GenerateConfig(context):
           'network': GlobalComputeUrl(context.env['project'],
                                       'networks',
                                       'default')
+      }],
+      'serviceAccounts': [{
+          'email': 'default',
+          'scopes': [
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring.write"
+          ]
       }]
   }
   res.append({

--- a/templates/container_instance.py
+++ b/templates/container_instance.py
@@ -34,7 +34,7 @@ def GenerateContainerInstance(context):
     prop[default.SRCIMAGE] = prop[C_IMAGE]
   else:
     prop[SRCIMAGE] = common.GlobalComputeLink(
-        'google-containers', 'images', prop[C_IMAGE])
+        'cos-cloud', 'images', prop[C_IMAGE])
   items.append(
       {
           'key': 'google-container-manifest',


### PR DESCRIPTION
+ Changing metadata key to `gce-container-declaration`
+ Adding serviceAccount + scopes for logging, so that the container VM can talk to logging