### PR TITLE
htcondor: Switch to Debian-provided package

### DIFF
--- a/examples/v2/htcondor/startup-compute.sh
+++ b/examples/v2/htcondor/startup-compute.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-apt-get update && apt-get install -y wget net-tools vim curl
-echo "deb http://research.cs.wisc.edu/htcondor/debian/stable/ jessie contrib" >> /etc/apt/sources.list
-wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -
-apt-get update && apt-get install -y condor
-if  dpkg -s condor >& /dev/null  ; then echo "yes"; else sleep 10; apt-get install -y condor; fi;
+apt-get update && export DEBIAN_FRONTEND=noninteractive; apt-get install -y net-tools vim curl htcondor
+
 cat <<EOF > /etc/condor/config.d/condor_config.local
 DISCARD_SESSION_KEYRING_ON_STARTUP=False
 CONDOR_ADMIN=EMAIL

--- a/examples/v2/htcondor/startup-master.sh
+++ b/examples/v2/htcondor/startup-master.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-apt-get update && apt-get install -y wget curl net-tools vim
-echo "deb http://research.cs.wisc.edu/htcondor/debian/stable/ jessie contrib" >> /etc/apt/sources.list
-wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -
-apt-get update && apt-get install -y condor
-if  dpkg -s condor >& /dev/null  ; then echo "yes"; else sleep 10; apt-get install -y condor; fi;
+apt-get update &&  export DEBIAN_FRONTEND=noninteractive; apt-get install -y curl net-tools vim htcondor
 cat <<EOF > /etc/condor/config.d/condor_config.local
 DISCARD_SESSION_KEYRING_ON_STARTUP=False
 DAEMON_LIST = MASTER, COLLECTOR, NEGOTIATOR

--- a/examples/v2/htcondor/startup-submit.sh
+++ b/examples/v2/htcondor/startup-submit.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-apt-get update && apt-get install -y wget net-tools vim curl gcc
-echo "deb http://research.cs.wisc.edu/htcondor/debian/stable/ jessie contrib" >> /etc/apt/sources.list
-wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -
+apt-get update &&  export DEBIAN_FRONTEND=noninteractive; apt-get install -y net-tools vim curl gcc htcondor
 apt-get update && apt-get install -y condor
-if  dpkg -s condor >& /dev/null  ; then echo "yes"; else sleep 10; apt-get install -y condor; fi;
 cat <<EOF > /etc/condor/config.d/condor_config.local
 DISCARD_SESSION_KEYRING_ON_STARTUP=False
 CONDOR_ADMIN=EMAIL


### PR DESCRIPTION
to resolve unsatisfiable dependency

The "htcondor" example no longer works because of an inconsistency between the current debian-9 image and the custom condor package. The condor package depends on libssl-1.0.0:

The following packages have unmet dependencies:
 condor : Depends: libssl1.0.0 (>= 1.0.1) but it is not installable
E: Unable to correct problems, you have held broken packages.


but the debian-9 image only offers:

libssl1.0.2/stable,stable,now 1.0.2l-2+deb9u3 amd64 [installed]
  Secure Sockets Layer toolkit - shared libraries


This pr switches the example to the Debian-provided htcondor package.


I tested as follows:
rudolf@condor-submit:~$ export LC_ALL=C
rudolf@condor-submit:~$ for i in 1 2 3; do condor_run "echo \$HOSTNAME $i ; sleep 10" & done; wait
[1] 12342
[2] 12343
[3] 12344
condor-compute-instance-4lh1 1
[1]   Done                    condor_run "echo \$HOSTNAME $i ; sleep 10"
condor-compute-instance-r7s4 3
condor-compute-instance-zf37 2
[2]-  Done                    condor_run "echo \$HOSTNAME $i ; sleep 10"
[3]+  Done                    condor_run "echo \$HOSTNAME $i ; sleep 10"
