### PR TITLE
sqladmin example - Added region to sql instance

### DIFF
--- a/examples/v2/sqladmin/python/sqladmin.py
+++ b/examples/v2/sqladmin/python/sqladmin.py
@@ -28,6 +28,7 @@ def GenerateConfig(context):
       'name': instance_name,
       'type': 'gcp-types/sqladmin-v1beta4:instances',
       'properties': {
+          'region': context.properties['region'],
           'settings': {
               'tier': context.properties['tier'],
               'backupConfiguration' : {


### PR DESCRIPTION
I noticed that the python template to provide sql instance was missing the REGION. This behavior would make Deployment Manager deploy the db instance in whatever the default region is on your `gcloud console`.
I added the region to the sql-instance resource. The region was already being used for the failover instance and read replicas so it was a matter of just adding the same line to the sql-instance.

Hope this makes sense. Let me know if you have doubts or if I missed something.