### PR TITLE
Corrected "ProjectAbbrevation" spelling

### DIFF
--- a/community/hierarchical_configuration/Basic/templates/simple_frontend.py
+++ b/community/hierarchical_configuration/Basic/templates/simple_frontend.py
@@ -22,8 +22,8 @@ def GenerateConfig(context):
     module = "frontend"
     cc = config_merger.ConfigContext(context.properties, module)
 
-    name_prefix = cc.configs["Org_Name"] + cc.configs["ProjectAbrevation"] + context.properties["envName"] + module
-    i_name_prefix = cc.configs["Org_Name"] + "-" + cc.configs["ProjectAbrevation"] + "-" + context.properties["envName"] + module
+    name_prefix = cc.configs["Org_Name"] + cc.configs["ProjectAbbrevation"] + context.properties["envName"] + module
+    i_name_prefix = cc.configs["Org_Name"] + "-" + cc.configs["ProjectAbbrevation"] + "-" + context.properties["envName"] + module
 
     instance = {
         'zone':


### PR DESCRIPTION
Please review this request, corrected "ProjectAbbrevation" spelling in community/hierarchical_configuration/Basic/templates/simple_frontend.py