### PR TITLE
HTCondor autoscaler for GCE

### DIFF
--- a/examples/v2/htcondor/README.md
+++ b/examples/v2/htcondor/README.md
@@ -36,7 +36,7 @@ To deploy, you must have a GCP account and have gcloud installed.
         condorversion: 8.4.11-1.el7
     ```
 
-    *   the `count` specifies the number of compute nodes in the cluster
+    *   the `count` specifies the number of compute nodes in the cluster provisioned at deployment time
     *   `zone` is the zone and region in which to launch the vms
     *   `email` is used for the configuration of htcondor (optional)
     *   `instancetype` is the type of nodes to use
@@ -107,6 +107,12 @@ To deploy, you must have a GCP account and have gcloud installed.
 
     ```
     % condor_history  --userlog /var/log/condor/jobs/stats.log
+    ```
+
+6.  Turn off all cluster resources when not in use, i.e.:
+
+    ```
+    % gcloud deployment-manager deployments delete mycondorcluster
     ```
 
 ## Files

--- a/examples/v2/htcondor/applications/Makefile
+++ b/examples/v2/htcondor/applications/Makefile
@@ -14,13 +14,10 @@
 
 #simple make file for compiling test programs
 
-all:primes simple
+all:primes
 
 primes:
 	gcc -o primes primes.c
 
-simple:
-	gcc -o simple simple.c
-
 clean:
-	rm primes simple
+	rm primes

--- a/examples/v2/htcondor/autoscaler/README.md
+++ b/examples/v2/htcondor/autoscaler/README.md
@@ -1,4 +1,4 @@
-# HTCondor Compute Cluster Resizing Based  on the Number of Jobs in the Queue
+# How to Resize an HTCondor Compute Cluster Based on the Number of Jobs in the Queue
 
 [HTCondor](https://research.cs.wisc.edu/htcondor/) is a framework for 
 solving computationally intensive problems.
@@ -36,21 +36,28 @@ We assume that an HTCondor cluster is running on GCP prior to installing and con
 ### Prerequisites
 
 Please follow instructions from https://cloud.google.com/solutions/high-throughput-computing-htcondor 
-to set up HTCondor in the GCP environment. Make sure to use attribute `setup_autoscaler = false` in 
-the properties of your condor-cluster, since this autoscaler will control the resources.
+to set up HTCondor in the GCP environment. Make sure to use attribute 
+`setup_autoscaler = false` in the properties of your condor-cluster, since 
+this autoscaler will control the resources.
 
 Other dependencies include Python, the GoogleApiClient and oauth2client 
 for Python (installed on the submit node by default).
 
-Note that the default quota on the number of instances (CPUs) may be too low 
-as set by default. The current instance quota can be checked on the quota
-console page and can be increased by clicking the “Edit Quota” button on 
-that page.
+Note that the default quota on the number of instances ("Compute Engine API / 
+CPUs" and/or "Compute Engine API / In-use IP addresses")
+may be too low as set by default. The current instance quota can be checked
+on the quota console page and can be increased by clicking the “Edit Quota” 
+button on that page.
 
-Access to the Google Cloud Compute Engine API should be enabled. The HTCondor
-submit node has the API enabled as part of its deployment. Please 
-follow instructions on https://cloud.google.com/apis/docs/enable-disable-apis 
-to enable this API from the management console to enable the API for other nodes.
+The service account used by the autoscaler to interact with GCE should have 
+access to the Google Cloud Compute Engine API. In the default deployment,
+we enable the service account of the submit node to have access to the API 
+i.e. the service account of the submit node has scope 
+https://www.googleapis.com/auth/compute. If you
+plan to execute the autoscaler from a different machine, make sure that the 
+service account of that machine has the compute 
+scope enabled (more infortmation at 
+https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#changeserviceaccountandscopes).
 
 The script assumes that the Managed Instance Group for the compute nodes is 
 provisioned. Make sure that the “Maximum number of instances” parameter is 
@@ -67,13 +74,13 @@ Script accepts the following arguments:
 | --zone        | -z | Name of GCP zone where the managed instance group is located |
 | --group_manager | -g | Name of the managed instance group |
 | --verbosity (optional) | -v | Show detail output. 1 - show basic debug info. 2 - show detail debug info |
-| --computeinstancelimit (optional) | -v | Maximum number of compute nodes that can be started from the script. Default is no limit enforced by this script |
+| --computeinstancelimit (optional) | -c | Maximum number of compute nodes that can be started from the script. Default is no limit enforced by this script |
 | --help (optional) | -h | Show command line help information |
  
 Example for starting the script:
 
 ```
-python autoscaler.py --project_id htcondor-project --region us-central1 --zone us-central1-f --group_manager condor-compute-igm --verbosity 2
+python autoscaler.py --project_id htcondor-project --region us-central1 --zone us-central1-f --group_manager condor-compute-igm --verbosity 1
 ```
 
 ### Deployment

--- a/examples/v2/htcondor/autoscaler/README.md
+++ b/examples/v2/htcondor/autoscaler/README.md
@@ -1,0 +1,105 @@
+# HTCondor Compute Cluster Resizing Based  on the Number of Jobs in the Queue
+
+[HTCondor](https://research.cs.wisc.edu/htcondor/) is a framework for 
+solving computationally intensive problems.
+When HTCondor is installed in the Cloud, it is beneficial to change the 
+number of compute instances based on the number of jobs in order to find 
+a solution faster. autoscaler.py is a python script that checks the total 
+number of jobs and  resizes the compute cluster in the Cloud to meet the demand.
+If this script is setup to run periodically, for example by a cron job, it will 
+update number of HTCondor compute instances to be proportional to the number
+of jobs waiting in the queue. That will improve the time to completion of 
+the jobs.
+
+## Features
+
+This script provisions compute resources for HTCondor proportionally to the 
+number of jobs in the queue (running, idle, etc.) In the default 
+implementation, the number of compute instances is calculated as directly 
+proportional to the total number of jobs in the job queue (e.g. one core per 
+job). It is possible to adjust the formula used to calculate the number of 
+running nodes for additional optimizations based on the size of jobs and job 
+submission pattern. Compute nodes are managed via a GCP managed instance group. 
+The size of the cluster is defined by the script by changing the TargetSize of 
+the group. Using managed instance groups is convenient to maintain the desired
+cluster size also with ephemeral resources, such as preemptible virtual machines.
+
+The script also verifies if compute nodes are idle (no jobs scheduled on the 
+HTCondor resource) and shut them down by removing them from the managed instance 
+group. In particular, when no jobs are in the queue anymore, the size of the 
+cluster will be zero (no compute nodes in the cluster.)
+
+## Getting Started
+
+We assume that an HTCondor cluster is running on GCP prior to installing and configuring the autoscaler script
+
+### Prerequisites
+
+Please follow instructions from https://cloud.google.com/solutions/high-throughput-computing-htcondor 
+to set up HTCondor in the GCP environment.
+
+Other dependencies include Python, the googleapiclient and oauth2client 
+for Python.
+
+Note that the default quota on the number of instances (CPUs) may be too low 
+as set by default. The current instance quota can be checked on the quota
+console page and can be increased by clicking the “Edit Quota” button on 
+that page.
+
+Access to the Google Cloud Compute Engine API should be enabled. Please 
+follow instructions on https://cloud.google.com/apis/docs/enable-disable-apis 
+to enable this API from the management console (note that the GCP installation 
+of the HTCondor cluster does not allow access to the Google API by default.)
+
+The script assumes that the Managed Instance Group for the compute nodes is 
+provisioned. Make sure that the “Maximum number of instances” parameter is 
+as big as the largest cluster that should be provisioned.
+ 
+### Script Arguments
+
+Script accepts the following arguments:
+ 
+| Argument      | Description    |
+| ------------- | -------------- |
+| --project_id  | GCP Project ID |
+| --region      | GCP region where the managed instance group is located |
+| --zone        | Name of GCP zone where the managed instance group is located |
+| --group_manager | Name of the managed instance group |
+| --debuglevel (optional) | Detailed debug information. 1-basic debug info. 2-detail debug info |
+| -h (optional) | Show command line help information |
+ 
+Example for starting the script:
+
+```
+python autoscaler.py slurm-var-demo us-central1 us-central1-f condor-compute-igm --debuglevel 1
+```
+
+### Deployment
+
+1.  Download the autoscaler.py script in a directory on condor-submit node 
+2.  Authenticate the user or service account associated with the node to access
+    the GCE API. Note that the instanceAdmin role will be sufficient. 
+    Alternatively, a new role that includes the ```compute.instanceGroupManagers.*```
+    permission set will provide a more granular permission scheme. 
+
+    Refer to 
+    https://cloud.google.com/sdk/docs/authorizing and
+    https://cloud.google.com/sdk/gcloud/reference/auth/login for more details on 
+    account authorization 
+    
+3.  Update the cron configuration to run the script periodically. For example, 
+    to run the script every minute, configure the cron job as following:
+    <nobr>
+    ```
+    * * * * *  /usr/bin/python /<directory_with_script>/autoscaler.py <arguments>
+    ```
+    </nobr>
+
+### Test
+
+You can test the functionality of the script by running jobs groups with 
+different expected execution length. You can use, for example, the application 
+provided in the “htcondor on GCP” solution to calculate the first x prime 
+numbers. Submit different job groups with various values for x (e.g. 400,000 
+and 4,000,000) and observe how the cluster size varies with time as jobs are 
+submitted, execute, and finish.

--- a/examples/v2/htcondor/autoscaler/README.md
+++ b/examples/v2/htcondor/autoscaler/README.md
@@ -36,7 +36,8 @@ We assume that an HTCondor cluster is running on GCP prior to installing and con
 ### Prerequisites
 
 Please follow instructions from https://cloud.google.com/solutions/high-throughput-computing-htcondor 
-to set up HTCondor in the GCP environment.
+to set up HTCondor in the GCP environment. Make sure to use attribute `setup_autoscaler = false` in 
+the properties of your condor-cluster, since this autoscaler will control the resources.
 
 Other dependencies include Python, the googleapiclient and oauth2client 
 for Python (installed on the submit node by default).

--- a/examples/v2/htcondor/autoscaler/README.md
+++ b/examples/v2/htcondor/autoscaler/README.md
@@ -73,7 +73,7 @@ Script accepts the following arguments:
 Example for starting the script:
 
 ```
-python autoscaler.py --project_id slurm-var-demo --region us-central1 --zone us-central1-f --group_manager condor-compute-igm --verbosity 2
+python autoscaler.py --project_id htcondor-project --region us-central1 --zone us-central1-f --group_manager condor-compute-igm --verbosity 2
 ```
 
 ### Deployment

--- a/examples/v2/htcondor/autoscaler/README.md
+++ b/examples/v2/htcondor/autoscaler/README.md
@@ -39,17 +39,17 @@ Please follow instructions from https://cloud.google.com/solutions/high-throughp
 to set up HTCondor in the GCP environment.
 
 Other dependencies include Python, the googleapiclient and oauth2client 
-for Python.
+for Python (installed on the submit node by default).
 
 Note that the default quota on the number of instances (CPUs) may be too low 
 as set by default. The current instance quota can be checked on the quota
 console page and can be increased by clicking the “Edit Quota” button on 
 that page.
 
-Access to the Google Cloud Compute Engine API should be enabled. Please 
+Access to the Google Cloud Compute Engine API should be enabled. The HTCondor
+submit node has the API enabled as part of its deployment. Please 
 follow instructions on https://cloud.google.com/apis/docs/enable-disable-apis 
-to enable this API from the management console (note that the GCP installation 
-of the HTCondor cluster does not allow access to the Google API by default.)
+to enable this API from the management console to enable the API for other nodes.
 
 The script assumes that the Managed Instance Group for the compute nodes is 
 provisioned. Make sure that the “Maximum number of instances” parameter is 
@@ -65,13 +65,13 @@ Script accepts the following arguments:
 | --region      | GCP region where the managed instance group is located |
 | --zone        | Name of GCP zone where the managed instance group is located |
 | --group_manager | Name of the managed instance group |
-| --debuglevel (optional) | Detailed debug information. 1-basic debug info. 2-detail debug info |
+| --debuglevel (optional) | Detailed debug information. 1 - basic debug info. 2 - detail debug info |
 | -h (optional) | Show command line help information |
  
 Example for starting the script:
 
 ```
-python autoscaler.py slurm-var-demo us-central1 us-central1-f condor-compute-igm --debuglevel 1
+python autoscaler.py --project_id=condor-cluster-project --region=us-central1 --zone=us-central1-f --group_manager=condor-compute-igm --debuglevel=2
 ```
 
 ### Deployment

--- a/examples/v2/htcondor/autoscaler/autoscaler.py
+++ b/examples/v2/htcondor/autoscaler/autoscaler.py
@@ -1,0 +1,256 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script for resizing managed instance group (MIG) cluster size based
+# on the number of jobs in the Condor Queue.
+
+from pprint import pprint
+from googleapiclient import discovery
+from oauth2client.client import GoogleCredentials
+
+import os
+import math
+import json
+import argparse
+
+parser = argparse.ArgumentParser("autoscaler.py")
+parser.add_argument("project_id", help="Project id", type=str)
+parser.add_argument("region", help="GCP region where the managed instance group is located", type=str)
+parser.add_argument("zone", help="Name of GCP zone where the managed instance group is located", type=str)
+parser.add_argument("group_manager", help="Name of the managed instance group", type=str)
+parser.add_argument("--debug-level", help="Show detailed debug information. 1-basic debug info. 2-detail debug info", type=int)
+args = parser.parse_args()
+
+# Project ID
+project = args.project_id #Ex:'slurm-var-demo'
+
+# Region where the managed instance group is located
+region = args.region #Ex: 'us-central1'
+
+# Name of the zone where the managed instance group is located
+zone = args.zone #Ex: 'us-central1-f'
+
+# The name of the managed instance group.
+instance_group_manager = args.group_manager #Ex: 'condor-compute-igm'
+
+# Default number of cores per intance, will be replaced with actual value
+cores_per_node = 2
+
+# Default number of running instances that the managed instance group should maintain at any given time. This number will go up and down based on the load (number of jobs in the queue)
+size = 0
+
+# Debug level: 1-print debug information, 2 - print detail debug information
+debug = 0
+if (args.debug-level):
+    debug = args.debug-level
+
+
+# Remove specified instance from MIG and decrease MIG size
+def deleteFromMig(instance):
+    instanceUrl = 'https://www.googleapis.com/compute/v1/projects/' \
+        + project + '/zones/' + zone + '/instances/' + instance
+    instances_to_delete = {'instances': [instanceUrl]}
+
+    requestDelInstance = \
+        service.instanceGroupManagers().deleteInstances(project=project,
+            zone=zone, instanceGroupManager=instance_group_manager,
+            body=instances_to_delete)
+    response = requestDelInstance.execute()
+    if debug > 0:
+        print 'Request to delete instance ' + instance
+        pprint(respDel)
+
+    return response
+
+
+def getCpuLimit():
+    request = service.regions().get(project=project, region=region,
+                                    fields='quotas')
+    response = request.execute()
+    cpuLimit = 0
+
+    quotas = response['quotas']
+    for quota in quotas:
+        if quota['metric'] == 'PREEMPTIBLE_CPUS':
+            cpuLimit = quota['limit']
+
+    return int(cpuLimit)
+
+
+def getInstanceTemplateInfo():
+    requestTemplateName = \
+        service.instanceGroupManagers().get(project=project, zone=zone,
+            instanceGroupManager=instance_group_manager,
+            fields='instanceTemplate')
+    responseTemplateName = requestTemplateName.execute()
+    template_name = ''
+
+    if debug > 1:
+        print 'Request for the template name'
+        pprint(responseTemplateName)
+
+    if len(responseTemplateName) > 0:
+        template_url = responseTemplateName.get('instanceTemplate')
+        template_url_partitioned = template_url.split('/')
+        template_name = \
+            template_url_partitioned[len(template_url_partitioned) - 1]
+
+    requestInstanceTemplate = \
+        service.instanceTemplates().get(project=project,
+            instanceTemplate=template_name, fields='properties')
+    responseInstanceTemplateInfo = requestInstanceTemplate.execute()
+
+    if debug > 1:
+        print 'Template information'
+        pprint(responseInstanceTemplateInfo['properties'])
+
+    machine_type = responseInstanceTemplateInfo['properties']['machineType']
+    is_preemtible = responseInstanceTemplateInfo['properties']['scheduling']['preemptible']
+    if debug > 0:
+        print 'Machine Type: ' + machine_type
+        print 'Is preemtible: ' + str(is_preemtible)
+    request = service.machineTypes().get(project=project, zone=zone,
+            machineType=machine_type)
+    response = request.execute()
+    guest_cpus = response['guestCpus']
+    if debug > 1:
+        print 'Machine information information'
+        pprint(responseInstanceTemplateInfo['properties'])
+    if debug > 0:
+        print 'Guest CPUs: ' + str(guest_cpus)
+
+    instanceTemlateInfo = {'machine_type': machine_type,
+                           'is_preemtible': is_preemtible,
+                           'guest_cpus': guest_cpus}
+    return instanceTemlateInfo
+
+
+# Obtain credentials
+credentials = GoogleCredentials.get_application_default()
+service = discovery.build('compute', 'v1', credentials=credentials)
+
+# Get total number of jobs in the queue that includes number of jos waiting as well as number of jobs already assigned to nodes
+queue_length_req = 'condor_q -totals | tail -n 1'
+queue_length_resp = os.popen(queue_length_req).read().split()
+
+if len(queue_length_resp) > 1:
+    queue = int(queue_length_resp[0])
+    idle_jobs = int(queue_length_resp[6])
+else:
+    queue = 0
+    idle_jobs = 0
+
+print 'Current queue length: ' + str(queue)
+print 'Idle jobs: ' + str(idle_jobs)
+
+instanceTemlateInfo = getInstanceTemplateInfo()  # test 'guest_cpus': 4, 'is_preemtible': True, 'machine_type': u'n1-standard-4'
+pprint(instanceTemlateInfo)
+
+cores_per_node = instanceTemlateInfo['guest_cpus']
+print 'Number of CPU per node: ' + str(cores_per_node)
+
+
+instance_limit = int(math.ceil(float(getCpuLimit())
+                     / float(cores_per_node)))
+print 'Instance limit: ' + str(instance_limit)
+
+
+# Get state for for all jobs in Condor
+name_req = 'condor_status  -af name state'
+slot_names = os.popen(name_req).read().splitlines()
+if debug > 1:
+    print 'Jobs in Condor'
+    print slot_names
+
+# Scaling down (if needed)
+# Find nodes that are not busy (all slots showing status as "Unclaimed")
+
+node_busy = {}
+for slot_name in slot_names:
+    name_status = slot_name.split()
+    if len(name_status) > 1:
+        name = name_status[0]
+        status = name_status[1]
+        slot_server = name.split('@')
+        slot = slot_server[0]
+        server = slot_server[1].split('.')[0]
+
+        if debug > 0:
+            print slot + ', ' + server + ', ' + status + '\n'
+
+        if server not in node_busy:
+            if status == 'Unclaimed':
+                node_busy[server] = False
+            else:
+                node_busy[server] = True
+        else:
+            if status != 'Unclaimed':
+                node_busy[server] = True
+print node_busy
+
+# Shut down nodes that are not busy
+for node in node_busy:
+    if not node_busy[node]:
+        print 'Will shut down: ' + node + ' ...'
+
+        respDel = deleteFromMig(node)
+        if debug > 1:
+            pprint(respDel)
+
+# Scale up (if needed)
+
+# Get current number of instances in the MIG
+requestGroupInfo = service.instanceGroupManagers().get(project=project,
+        zone=zone, instanceGroupManager=instance_group_manager)
+responseGroupInfo = requestGroupInfo.execute()
+currentTarget = int(responseGroupInfo['targetSize'])
+print 'Current target:' + str(currentTarget)
+
+if debug > 1:
+    print 'MIG Information:'
+    print responseGroupInfo
+
+# Calculate number instances to satisfy current job queue length
+if queue > 0:
+    size = int(math.ceil(float(queue) / float(cores_per_node)))
+    if debug>1:
+       print "Calucalting size of MIG: " + str(queue) + "/" + str(cores_per_node) + " = " + str(size)
+else:
+    size = 0
+
+# Limit number of instances based on quota
+size = min(instance_limit, size)
+
+print 'New MIG target size: ' + str(size)
+
+if size > 0 and size <= currentTarget:
+    print 'Nothing to do. Current target is sufficient for the queue length'
+    exit()
+
+if size == 0 and currentTarget == 0:
+    print 'No jobs in the queue. Nothing to do'
+    exit()
+print
+
+# Number of instances request to resize
+request = service.instanceGroupManagers().resize(project=project,
+        zone=zone, instanceGroupManager=instance_group_manager,
+        size=size)
+response = request.execute()
+if debug > 1:
+    print 'requesting new MIG size:'
+    pprint(response)

--- a/examples/v2/htcondor/autoscaler/autoscaler.py
+++ b/examples/v2/htcondor/autoscaler/autoscaler.py
@@ -24,40 +24,46 @@ from oauth2client.client import GoogleCredentials
 
 import os
 import math
-import json
 import argparse
 
 parser = argparse.ArgumentParser("autoscaler.py")
-parser.add_argument("project_id", help="Project id", type=str)
-parser.add_argument("region", help="GCP region where the managed instance group is located", type=str)
-parser.add_argument("zone", help="Name of GCP zone where the managed instance group is located", type=str)
-parser.add_argument("group_manager", help="Name of the managed instance group", type=str)
-parser.add_argument("--debug-level", help="Show detailed debug information. 1-basic debug info. 2-detail debug info", type=int)
+parser.add_argument("--project_id", help="Project id", type=str)
+parser.add_argument("--region", help="GCP region where the managed instance group is located", type=str)
+parser.add_argument("--zone", help="Name of GCP zone where the managed instance group is located", type=str)
+parser.add_argument("--group_manager", help="Name of the managed instance group", type=str)
+parser.add_argument("--debuglevel", help="Show detailed debug information. 1-basic debug info. 2-detail debug info", type=int)
 args = parser.parse_args()
 
 # Project ID
-project = args.project_id #Ex:'slurm-var-demo'
+project = args.project_id  # Ex:'slurm-var-demo'
 
 # Region where the managed instance group is located
-region = args.region #Ex: 'us-central1'
+region = args.region  # Ex: 'us-central1'
 
 # Name of the zone where the managed instance group is located
-zone = args.zone #Ex: 'us-central1-f'
+zone = args.zone  # Ex: 'us-central1-f'
 
 # The name of the managed instance group.
-instance_group_manager = args.group_manager #Ex: 'condor-compute-igm'
+instance_group_manager = args.group_manager  # Ex: 'condor-compute-igm'
 
 # Default number of cores per intance, will be replaced with actual value
-cores_per_node = 2
+cores_per_node = 4
 
 # Default number of running instances that the managed instance group should maintain at any given time. This number will go up and down based on the load (number of jobs in the queue)
 size = 0
 
 # Debug level: 1-print debug information, 2 - print detail debug information
 debug = 0
-if (args.debug-level):
-    debug = args.debug-level
+if (args.debuglevel):
+    debug = args.debuglevel
 
+if debug > 1:
+    print 'Launching autoscaler.py with the following arguments:'
+    print 'project_id: ' + project
+    print 'region: ' + region
+    print 'zone: ' + zone
+    print 'group_manager: ' + instance_group_manager
+    print 'debuglevel: ' + str(debug)
 
 # Remove specified instance from MIG and decrease MIG size
 def deleteFromMig(instance):

--- a/examples/v2/htcondor/condor-cluster.yaml
+++ b/examples/v2/htcondor/condor-cluster.yaml
@@ -21,6 +21,7 @@ resources:
   type: condor.jinja
   properties:
     count: 2
+    setup_autoscaler: true
     zone: us-central1-f
     email: someone@somewhere.com
     instancetype: n1-standard-4

--- a/examples/v2/htcondor/condor.jinja
+++ b/examples/v2/htcondor/condor.jinja
@@ -88,6 +88,12 @@ resources:
       - email: "default"
         scopes:
         - "https://www.googleapis.com/auth/logging.write"
+        - "https://www.googleapis.com/auth/compute"
+        - "https://www.googleapis.com/auth/servicecontrol"
+        - "https://www.googleapis.com/auth/service.management.readonly"
+        - "https://www.googleapis.com/auth/monitoring.write"
+        - "https://www.googleapis.com/auth/trace.append"
+        - "https://www.googleapis.com/auth/devstorage.read_only"
     tags:
       items:
         - condor-submit
@@ -137,6 +143,8 @@ resources:
     instanceTemplate: $(ref.condor-compute.selfLink)
     targetSize: {{ properties["count"] }}
     zone: {{ properties["zone"] }}
+
+{% if properties['setup_autoscaler'] %}
 - name: condor-compute-as
   type: compute.v1.autoscaler
   properties:
@@ -145,6 +153,8 @@ resources:
     autoscalingPolicy:
       minNumReplicas: {{ properties["count"] }}
       maxNumReplicas: {{ properties["count"] }}
+{% endif %}
+
 outputs:
 - name: condor-submit-host-ip,
   value: \$(ref.condor-submit.networkInterfaces[0].accessConfigs[0].natIP)

--- a/examples/v2/htcondor/condor.jinja.schema
+++ b/examples/v2/htcondor/condor.jinja.schema
@@ -42,6 +42,7 @@ optional:
 - email
 - count
 - condorversion
+- setup_autoscaler
 
 properties:
   zone:
@@ -70,3 +71,7 @@ properties:
     type: string
     default: "CONDORVERSION"
     description: optional version of HTCondor, among the stable ones. If not provided, the system installs the latest stable version.
+  setup_autoscaler:
+    type: boolean
+    default: true
+    description: optional flag to setup an autoscaler with the MIG, to maintain the machines at the desired count (e.g. if PVM)

--- a/examples/v2/htcondor/startup-submit-centos.sh
+++ b/examples/v2/htcondor/startup-submit-centos.sh
@@ -48,22 +48,4 @@ EOF
 mkdir -p /etc/google-fluentd/config.d/
 mv condor.conf /etc/google-fluentd/config.d/
 
-cat <<EOF > condor-jobs.conf
-<source>
-type tail
-format multiline
-format_firstline /^\.\.\./
-format1 /^\\.\\.\\.\\n... \\((?<job>[^\.]*)\\.(?<subjob>[^\\.]*)\\.(?<run>[^\\)]*)\\).*Usr 0 (?<usrh>[^:]*):(?<usrm>[^:]*):(?<usrs>[^,]*), Sys 0 (?<sysh>[^:]*):(?<sysm>[^
-:]*):(?<syss>[^ ]*)  -  Run Remote Usage.*/
-types usrh:integer,usrm:integer,usrs:integer,sysh:integer,sysm:integer,syss:integer
-path /var/log/condor/jobs/*.log
-pos_file /var/lib/google-fluentd/pos/condor-jobs.pos
-read_from_head true
-tag condor
-</source>
-EOF
-mv condor-jobs.conf /etc/google-fluentd.config.d/
-mkdir -p /var/log/condor/jobs
-touch /var/log/condor/jobs/stats.log
-chmod 666 /var/log/condor/jobs/stats.log
 service google-fluentd restart


### PR DESCRIPTION
This branch adds a simple python autoscaler for HTCondor deployments in GCE. It uses the existing (slightly modified) GDM scripts to deploy HTCondor. It provides a script that can be run periodically to add / remove nodes to a MIG, based on the number of jobs in the queue. More details are in the readme of the autoscaler directory. 