### PR TITLE
 Remove unnecessary location field from cloudfunctions-v1 resource snippet template.

### DIFF
--- a/google/resource-snippets/cloudfunctions-v1/configurable_functions.jinja
+++ b/google/resource-snippets/cloudfunctions-v1/configurable_functions.jinja
@@ -18,7 +18,6 @@ resources:
   name: {{ env['deployment'] }}-my-function
   properties:
     parent: projects/{{ env['project'] }}/locations/{{ properties['region'] }}
-    location: {{ properties['region'] }}
     function: my-{{ env['deployment'] }}
     sourceArchiveUrl: gs://cloud-function-sample/function.zip
     entryPoint: {{ properties['entryPoint'] }}


### PR DESCRIPTION
Patch doesn't work with non existent field location:
Invalid JSON payload received. Unknown name "location" at 'function'