### PR TITLE
Shared VPC projects can be created in a folder

### DIFF
--- a/examples/v2/project_creation/README.md
+++ b/examples/v2/project_creation/README.md
@@ -94,7 +94,7 @@ and their resources. Avoid creating other GCP resources in the Creation project.
 
     *   Set the name of the new project you want to create. It must be unique
         among all project names.
-    *   Set the organization id.
+    *   Set the organization id (or the folder id).
     *   Set the billing account to use.
     *   Set the APIs to turn on.
     *   Set the service accounts to create.

--- a/examples/v2/project_creation/config.yaml
+++ b/examples/v2/project_creation/config.yaml
@@ -10,6 +10,8 @@ resources:
     properties:
         # Change this to your organization ID.
         organization-id: "ORG_ID"
+        # You can also create the project in a folder.
+        #parent-folder-id: "FOLDER_ID"
 
         # Change the following to your organization's billing account
         billing-account-name: billingAccounts/BILLING_ACCOUNT_ID
@@ -65,4 +67,3 @@ resources:
                   # This is already not on the project, but in case it shows up, let's
                   # remove it.
                   - serviceAccount:1234567890@cloudservices.gserviceaccount.com
-

--- a/examples/v2/project_creation/config_shared_vpc.yaml
+++ b/examples/v2/project_creation/config_shared_vpc.yaml
@@ -8,6 +8,9 @@ resources:
   properties:
     # CHANGEME: Change this to your organization ID.
     organization-id: "ORG_ID"
+    # You can also create the project in a folder. You still need to give
+    # the Organization ID above to configure Shared VPC.
+    #parent-folder-id: "FOLDER_ID"
     # CHANGEME: Change the following to your organization's billing account
     billing-account-name: billingAccounts/BILLING_ACCOUNT_ID
     # The apis to enable in the new project.
@@ -43,6 +46,9 @@ resources:
   properties:
     # CHANGEME: Change this to your organization ID.
     organization-id: "ORG_ID"
+    # You can also create the project in a folder. You still need to give
+    # the Organization ID above to configure Shared VPC.
+    #parent-folder-id: "FOLDER_ID"
     # CHANGEME: Change the following to your organization's billing account
     billing-account-name: billingAccounts/BILLING_ACCOUNT_ID
     # The apis to enable in the new project.

--- a/examples/v2/project_creation/project.py
+++ b/examples/v2/project_creation/project.py
@@ -25,17 +25,17 @@ def GenerateConfig(context):
 
   if not IsProjectParentValid(context.properties):
     sys.exit(('Invalid [organization-id, parent-folder-id], '
-              'must specify exactly one.'))
+              'must specify at least one.'))
 
   parent_type = ''
   parent_id = ''
 
-  if 'organization-id' in context.properties:
-    parent_type = 'organization'
-    parent_id = context.properties['organization-id']
-  else:
+  if 'parent-folder-id' in context.properties:
     parent_type = 'folder'
     parent_id = context.properties['parent-folder-id']
+  else:
+    parent_type = 'organization'
+    parent_id = context.properties['organization-id']
 
   if 'project-name' in context.properties:
     project_name = context.properties['project-name']
@@ -216,11 +216,6 @@ def GenerateConfig(context):
 
 def IsProjectParentValid(properties):
   """ A helper function to validate that the project is either under a folder
-      or under an organization and not both
+      or under an organization
   """
-  if ('organization-id' not in properties and
-      'parent-folder-id' not in properties):
-    return False
-  if 'organization-id' in properties and 'parent-folder-id' in properties:
-    return False
-  return True
+  return ('organization-id' in properties or 'parent-folder-id' in properties)


### PR DESCRIPTION
Fix #351

We didn't allow the user to specify both an org ID and a folder ID,
but both are needed to create Shared VPC projects in a folder.

If both an org ID and a folder ID are provided, the project will
be created in the folder and not in at the org root.