### PR TITLE
Support updating a trigger

### DIFF
--- a/community/cloud-foundation/templates/cloudbuild/trigger.py
+++ b/community/cloud-foundation/templates/cloudbuild/trigger.py
@@ -41,6 +41,22 @@ def generate_config(context):
         }
     }
 
+    # build trigger update action
+    build_trigger_update = {
+        'name':
+            name + '-update',
+        'action':
+            'gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.patch',
+        'metadata': {
+            'runtimePolicy': ['UPDATE_ON_CHANGE'],
+        },
+        'properties': {
+            'id': build_trigger_id,
+            'triggerId': build_trigger_id,
+            'triggerTemplate': properties['triggerTemplate']
+        }
+    }
+
     optional_properties = [
         'description',
         'disabled',
@@ -52,13 +68,17 @@ def generate_config(context):
     for prop in optional_properties:
         if prop in properties:
             build_trigger_create['properties'][prop] = properties[prop]
+            build_trigger_update['properties'][prop] = properties[prop]
 
     if build_def:
         build_trigger_create['properties']['build'] = build_def
+        build_trigger_update['properties']['build'] = build_def
     elif build_filename:
         build_trigger_create['properties']['filename'] = build_filename
+        build_trigger_update['properties']['filename'] = build_filename
 
     resources.append(build_trigger_create)
+    resources.append(build_trigger_update)
 
     # build trigger delete action
     build_trigger_delete = {


### PR DESCRIPTION
**Summary**

This PR lets you update a trigger without deleting/recreating it.

**Note**

The [documentation ](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.triggers#BuildTrigger)states that the ``id`` is output only but if try to update a trigger you always get a 400 error, unless you add the ``id``. I confirmed this by looking to the Google Cloud Console that uses the ``id`` when updating a trigger.
