### PR TITLE
instance.py: Remove duplicate tags definition 

### DIFF
--- a/community/cloud-foundation/templates/instance/instance.py.schema
+++ b/community/cloud-foundation/templates/instance/instance.py.schema
@@ -139,17 +139,6 @@ properties:
               type: string
             value:
               type: [string, number, boolean]
-  tags:
-    type: object
-    required:
-      - items
-    description: Tags to apply to this instance.
-    properties:
-      items:
-        type: array
-        description: An array of tags.
-        items:
-          type: string
   serviceAccounts:
     type: array
     description: |


### PR DESCRIPTION
This should fix `found duplicate key "tags"` warning. 
