### PR TITLE
Support update operations on Kubernetes resources.

### DIFF
--- a/examples/v2/gke/jinja/cluster.jinja
+++ b/examples/v2/gke/jinja/cluster.jinja
@@ -59,6 +59,20 @@ resources:
         location: HEADER
         value: >
           $.concat("Bearer ", $.googleOauth2AccessToken())
+      - fieldName: metadata.resourceVersion
+        location: BODY
+        methodMatch: ^(PUT|PATCH)$
+        value: $.resource.self.metadata.resourceVersion
+{% if endpoint is 'api/v1' %}
+    collectionOverrides:
+    - collection: '/api/v1/namespaces/{namespace}/services'
+      options:
+        inputMappings:
+        - fieldName: spec.clusterIP
+          location: BODY
+          methodMatch: ^(PUT|PATCH)$
+          value: $.resource.self.spec.clusterIP
+{% endif %}
     descriptorUrl: https://$(ref.{{ CLUSTER_NAME }}.endpoint)/swaggerapi/{{ endpoint }}
 {% endfor %}
 

--- a/examples/v2/gke/jinja/cluster.jinja
+++ b/examples/v2/gke/jinja/cluster.jinja
@@ -63,7 +63,7 @@ resources:
         location: BODY
         methodMatch: ^(PUT|PATCH)$
         value: $.resource.self.metadata.resourceVersion
-{% if endpoint is 'api/v1' %}
+    {% if endpoint == 'api/v1' %}
     collectionOverrides:
     - collection: '/api/v1/namespaces/{namespace}/services'
       options:
@@ -72,7 +72,7 @@ resources:
           location: BODY
           methodMatch: ^(PUT|PATCH)$
           value: $.resource.self.spec.clusterIP
-{% endif %}
+    {% endif %}
     descriptorUrl: https://$(ref.{{ CLUSTER_NAME }}.endpoint)/swaggerapi/{{ endpoint }}
 {% endfor %}
 

--- a/examples/v2/gke/python/cluster.py
+++ b/examples/v2/gke/python/cluster.py
@@ -88,8 +88,24 @@ def GenerateConfig(context):
                     'location': 'HEADER',
                     'value': '$.concat("Bearer ",'
                              '$.googleOauth2AccessToken())'
+                }, {
+                    'fieldName': 'metadata.resourceVersion',
+                    'location': 'BODY',
+                    'methodMatch': '^(PUT|PATCH)$',
+                    'value': '$.resource.self.metadata.resourceVersion'
                 }]
             },
+            'collectionOverrides': [{
+                'collection': '/api/v1/namespaces/{namespace}/services',
+                'options': {
+                    'inputMappings': [{
+                        'fieldName': 'spec.clusterIP',
+                        'location': 'BODY',
+                        'methodMatch': '^(PUT|PATCH)$',
+                        'value': '$.resource.self.spec.clusterIP'
+                    }]
+                }
+            }] if endpoint == 'api/v1' else [],
             'descriptorUrl':
                 ''.join([
                     'https://$(ref.', cluster_name, '.endpoint)/swaggerapi/',


### PR DESCRIPTION
* Generic support for `resourceVersion` to avoid race updates for all k8s objects.
* Specific support for immutable `clusterIP` on `Service` objects.

Fixes #379, #380.