### PR TITLE
Fix default owner always being set for datasets

### DIFF
--- a/community/cloud-foundation/templates/bigquery/bigquery_dataset.py
+++ b/community/cloud-foundation/templates/bigquery/bigquery_dataset.py
@@ -54,7 +54,7 @@ def generate_config(context):
 
         properties['access'] = context.properties['access']
 
-        if 'setDefaultOwner' in context.properties:
+        if context.properties.get('setDefaultOwner', False):
             # Build the default owner for the dataset.
             base = '@cloudservices.gserviceaccount.com'
             default_dataset_owner = context.env['project_number'] + base


### PR DESCRIPTION
The default value of the setDefaultOwner field in the schema is False, so it is always set in context.properties. The code checks for the existence of the field (which is always true), thus it always sets the default owner, even if setDefaultOwner is set to false.

Rather, it should check if the field is explicitly set to true.