### PR TITLE
add dns v1beta2 private zone samples

### DIFF
--- a/google/resource-snippets/dns-v1beta2/dns_private.jinja
+++ b/google/resource-snippets/dns-v1beta2/dns_private.jinja
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc. All rights reserved.
+# Copyright 2019 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/resource-snippets/dns-v1beta2/dns_private.jinja
+++ b/google/resource-snippets/dns-v1beta2/dns_private.jinja
@@ -1,3 +1,18 @@
+  
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 resources:
 - name: network-1-{{ env["deployment"] }}
   type: gcp-types/compute-v1:networks

--- a/google/resource-snippets/dns-v1beta2/dns_private.jinja
+++ b/google/resource-snippets/dns-v1beta2/dns_private.jinja
@@ -1,0 +1,30 @@
+resources:
+- name: network-1-{{ env["deployment"] }}
+  type: gcp-types/compute-v1:networks
+- name: {{ properties["zoneName"] }}
+  type: gcp-types/dns-{{ properties["version"] }}:managedZones
+  properties:
+    description: >
+      Managed zone for deployment {{ env["deployment"] }}
+        and zone {{ properties["zoneName"] }}
+    dnsName: {{ properties["zoneDnsName"] }}
+    visibility: private
+    privateVisibilityConfig:
+      networks:
+        - networkUrl: $(ref.network-1-{{ env["deployment"] }}.selfLink)
+- name: {{ properties["rrsetName"] }}
+  type: gcp-types/dns-v1:resourceRecordSets
+  properties:
+    name: {{ properties["rrsetDomain"] }}
+    managedZone: $(ref.{{ properties["zoneName"] }}.name)
+    records:
+    - type: A
+      ttl: 50
+      rrdatas:
+      - 10.40.10.0
+    {% if properties['aaaa_record'] == 'true' %}
+    - type: AAAA
+      ttl: 40
+      rrdatas:
+      - 1:2::ffff:101
+    {% endif %}

--- a/google/resource-snippets/dns-v1beta2/dns_private.jinja
+++ b/google/resource-snippets/dns-v1beta2/dns_private.jinja
@@ -1,4 +1,3 @@
-  
 # Copyright 2018 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/resource-snippets/dns-v1beta2/dns_private.yaml
+++ b/google/resource-snippets/dns-v1beta2/dns_private.yaml
@@ -1,0 +1,13 @@
+imports:
+- path: dns_private.jinja
+
+resources:
+- name: rrset-template-1
+  type: dns_private.jinja
+  properties:
+    rrsetDomain: dm-testing-a-record.com
+    rrsetName: dm_testing_rrset_1
+    zoneDnsName: dm-testing-a-record.com
+    zoneName: dm_testing_zone_1
+    version: v1
+    aaaa_record: true

--- a/google/resource-snippets/dns-v1beta2/dns_private.yaml
+++ b/google/resource-snippets/dns-v1beta2/dns_private.yaml
@@ -1,3 +1,17 @@
+# Copyright 2019 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 imports:
 - path: dns_private.jinja
 


### PR DESCRIPTION
sample for actuating dns v1beta2 private zones: https://cloud.google.com/blog/products/networking/introducing-private-dns-zones-resolve-to-keep-internal-networks-concealed
