### PR TITLE
Amend existing GCS bucket templates to allow domain-named buckets

### DIFF
--- a/community/cloud-foundation/templates/gcs_bucket/examples/gcs_bucket.yaml
+++ b/community/cloud-foundation/templates/gcs_bucket/examples/gcs_bucket.yaml
@@ -5,7 +5,8 @@
 # For bucket and object naming guidelines,
 # refer to https://cloud.google.com/storage/docs/naming.
 #
-# Replaxe the <FIXME:bucket_resource_name> placeholder with a unique name for the bucket resource within Deployment Manager
+# Replace the <FIXME:bucket_resource_name> placeholder with a name for the
+# deployment manager resource representing the bucket
 # Replace the <FIXME:bucket_name> placeholder with a globally unique storage
 # bucket name. For details, refer to
 # https://cloud.google.com/storage/docs/json_api/v1/buckets.

--- a/community/cloud-foundation/templates/gcs_bucket/examples/gcs_bucket.yaml
+++ b/community/cloud-foundation/templates/gcs_bucket/examples/gcs_bucket.yaml
@@ -5,6 +5,7 @@
 # For bucket and object naming guidelines,
 # refer to https://cloud.google.com/storage/docs/naming.
 #
+# Replaxe the <FIXME:bucket_resource_name> placeholder with a unique name for the bucket resource within Deployment Manager
 # Replace the <FIXME:bucket_name> placeholder with a globally unique storage
 # bucket name. For details, refer to
 # https://cloud.google.com/storage/docs/json_api/v1/buckets.
@@ -14,10 +15,10 @@ imports:
     name: gcs_bucket.py
 
 resources:
-  - name: <FIXME:bucket_name>
+  - name: <FIXME:bucket_resource_name>
     type: gcs_bucket.py
     properties:
-      name: <FIXME:bucket_name>
+      bucketName: <FIXME:bucket_name>
       location: us-east1
       versioning:
         enabled: True

--- a/community/cloud-foundation/templates/gcs_bucket/examples/gcs_bucket_iam_bindings.yaml
+++ b/community/cloud-foundation/templates/gcs_bucket/examples/gcs_bucket_iam_bindings.yaml
@@ -8,6 +8,7 @@
 # IAM Policies are also applied with the `bindings` section.
 #
 # Replace the following placeholders with the relevant values:
+#   <FIXME:bucket_resource_name>: a unique name for the bucket resource within Deployment Manager
 #   <FIXME:bucket_name>: a globally unique storage bucket name
 #   <FIXME:user_account_email_address>: a valid user account
 #   <FIXME:service_account_email_address>: a valid service account email
@@ -21,10 +22,10 @@ imports:
     name: gcs_bucket.py
 
 resources:
-  - name: <FIXME:bucket_name>
+  - name: <FIXME:bucket_resource_name>
     type: gcs_bucket.py
     properties:
-      name: <FIXME:bucket_name>
+      bucketName: <FIXME:bucket_name>
       location: us-east1
       versioning:
         enabled: True

--- a/community/cloud-foundation/templates/gcs_bucket/examples/gcs_bucket_lifecycle.yaml
+++ b/community/cloud-foundation/templates/gcs_bucket/examples/gcs_bucket_lifecycle.yaml
@@ -6,6 +6,7 @@
 # For bucket and object naming guidelines,
 # refer to https://cloud.google.com/storage/docs/naming.
 #
+# Replaxe the <FIXME:bucket_resource_name> placeholder with a unique name for the bucket resource within Deployment Manager
 # Replace the <FIXME:bucket_name> placeholder with a globally unique storage
 # bucket name. For details, refer to
 # https://cloud.google.com/storage/docs/json_api/v1/buckets.
@@ -15,10 +16,10 @@ imports:
     name: gcs_bucket.py
 
 resources:
-  - name: <FIXME:bucket_name>
+  - name: <FIXME:bucket_resource_name>
     type: gcs_bucket.py
     properties:
-      name: <FIXME:bucket_name>
+      bucketName: <FIXME:bucket_name>
       location: us-east1
       versioning:
         enabled: True

--- a/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py
+++ b/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py
@@ -19,14 +19,15 @@ def generate_config(context):
 
     resources = []
     project_id = context.env['project']
-    bucket_name = context.properties.get('name', context.env['name'])
+    bucket_name = context.properties.get('bucketName', context.env['name'])
+    bucket_resource_name = context.env['name'] + '-bucket'
 
     # output variables
-    bucket_selflink = '$(ref.{}.selfLink)'.format(bucket_name)
+    bucket_selflink = '$(ref.{}.selfLink)'.format(bucket_resource_name)
     bucket_uri = 'gs://' + bucket_name + '/'
 
     bucket = {
-        'name': bucket_name,
+        'name': bucket_resource_name,
         'type': 'storage.v1.bucket',
         'properties': {
             'project': project_id,
@@ -57,11 +58,11 @@ def generate_config(context):
     bindings = context.properties.get('bindings', [])
     if bindings:
         iam_policy = {
-            'name': bucket_name + '-iampolicy',
+            'name': bucket_resource_name + '-iampolicy',
             'action': (storage_provider_type),
             'properties':
                 {
-                    'bucket': '$(ref.' + bucket_name + '.name)',
+                    'bucket': '$(ref.' + bucket_resource_name + '.name)',
                     'project': project_id,
                     'bindings': bindings
                 }

--- a/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py
+++ b/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py
@@ -62,7 +62,7 @@ def generate_config(context):
             'action': (storage_provider_type),
             'properties':
                 {
-                    'bucket': '$(ref.' + bucket_resource_name + '.name)',
+                    'bucket': '$(ref.' + bucket_resource_name + '.bucketName)',
                     'project': project_id,
                     'bindings': bindings
                 }

--- a/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py.schema
+++ b/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py.schema
@@ -24,7 +24,7 @@ imports:
   - path: gcs_bucket.py
 
 required:
-  - name
+  - bucketName
 
 properties:
   bucketName:

--- a/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py.schema
+++ b/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py.schema
@@ -27,7 +27,7 @@ required:
   - name
 
 properties:
-  name:
+  bucketName:
     type: string
     description: The name of the bucket.
   location:

--- a/community/cloud-foundation/templates/gcs_bucket/tests/integration/gcs_bucket.bats
+++ b/community/cloud-foundation/templates/gcs_bucket/tests/integration/gcs_bucket.bats
@@ -21,6 +21,7 @@ if [[ -e "${RANDOM_FILE}" ]]; then
     CONFIG=".${DEPLOYMENT_NAME}.yaml"
     # Test specific variables:
     export BUCKET_NAME="test-bucket-${RAND}"
+    export BUCKET_RESOURCE_NAME=${BUCKET_NAME}
     export SA_NAME="${BUCKET_NAME}@${CLOUD_FOUNDATION_PROJECT_ID}.iam.gserviceaccount.com"
     export SA_FQDN="serviceAccount:${SA_NAME}"
     export ROLE="roles/storage.objectViewer"

--- a/community/cloud-foundation/templates/gcs_bucket/tests/integration/gcs_bucket.yaml
+++ b/community/cloud-foundation/templates/gcs_bucket/tests/integration/gcs_bucket.yaml
@@ -2,6 +2,7 @@
 #
 # Variables (declared in the gcs_bucket.bats file):
 #   RAND: a random string used by the testing suite
+#   BUCKET_RESOURCE_NAME: a unique (within the deployment) name for the bucket resource
 #   BUCKET_NAME: a globally unique Cloud Storage bucket name
 #   ROLE: a role to be assigned to member(s); e.g., roles/storage.objectViewer
 #   SA_FQDN: a ServiceAccount FQDN serviceAccount:<sa_account>
@@ -11,10 +12,10 @@ imports:
     name: gcs_bucket.py
 
 resources:
-  - name: ${BUCKET_NAME}
+  - name: ${BUCKET_RESOURCE_NAME}
     type: gcs_bucket.py
     properties:
-      name: ${BUCKET_NAME}
+      bucketName: ${BUCKET_NAME}
       location: us-east1
       versioning:
         enabled: True


### PR DESCRIPTION
This template makes use of references, which require the names of the resources being referenced to not include a '.' character in the name. Because the resource name and the bucket name have been one in the same for this template, a domain-named bucket causes
 the deployment to fail because the reference cannot be resolved.

To fix the issue, this separates the name of the bucket (with the domain) from the name of the resource, allowing domain-named buckets while still preserving the references being used throughout the template.