### PR TITLE
Don't require logging object prefix

### DIFF
--- a/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py.schema
+++ b/community/cloud-foundation/templates/gcs_bucket/gcs_bucket.py.schema
@@ -90,7 +90,6 @@ properties:
     type: object
     required:
       - logBucket
-      - logObjectPrefix
     properties:
       logBucket:
         type: string


### PR DESCRIPTION
The default is pretty sane:

> Optionally, you can set the log_object_prefix object prefix for your log objects. The object prefix forms the beginning of the log object name. It can be at most 900 characters and must be a valid object name. By default, the object prefix is the name of the bucket for which the logs are enabled.

https://cloud.google.com/storage/docs/access-logs