### PR TITLE
Use official repository path in pipeline examples

### DIFF
--- a/community/cloud-foundation/pipeline/app/Jenkinsfile
+++ b/community/cloud-foundation/pipeline/app/Jenkinsfile
@@ -7,7 +7,7 @@
 def config_dir = "pipeline/app" // relative to ${cft_dir}
 
 def env = "~/pipeline-vars"
-def repo = "https://github.com/sourced/deploymentmanager-samples"
+def repo = "https://github.com/GoogleCloudPlatform/deploymentmanager-samples"
 def branch = "pipeline"
 def git_dir = "cft"
 def cft_dir = "community/cloud-foundation"

--- a/community/cloud-foundation/pipeline/network/Jenkinsfile
+++ b/community/cloud-foundation/pipeline/network/Jenkinsfile
@@ -7,7 +7,7 @@
 def config_dir = "pipeline/network" // relative to ${cft_dir}
 
 def env = "~/pipeline-vars"
-def repo = "https://github.com/sourced/deploymentmanager-samples"
+def repo = "https://github.com/GoogleCloudPlatform/deploymentmanager-samples"
 def branch = "pipeline"
 def git_dir = "cft"
 def cft_dir = "community/cloud-foundation"

--- a/community/cloud-foundation/pipeline/project/Jenkinsfile
+++ b/community/cloud-foundation/pipeline/project/Jenkinsfile
@@ -7,7 +7,7 @@
 def config_dir = "pipeline/project" // relative to ${cft_dir}
 
 def env = "~/pipeline-vars"
-def repo = "https://github.com/sourced/deploymentmanager-samples"
+def repo = "https://github.com/GoogleCloudPlatform/deploymentmanager-samples"
 def branch = "pipeline"
 def git_dir = "cft"
 def cft_dir = "community/cloud-foundation"

--- a/community/cloud-foundation/pipeline/teardown/Jenkinsfile
+++ b/community/cloud-foundation/pipeline/teardown/Jenkinsfile
@@ -7,7 +7,7 @@
 def config_dir = "pipeline/network pipeline/app" // relative to ${cft_dir}
 
 def env = "~/pipeline-vars"
-def repo = "https://github.com/sourced/deploymentmanager-samples"
+def repo = "https://github.com/GoogleCloudPlatform/deploymentmanager-samples"
 def branch = "pipeline"
 def git_dir = "cft"
 def cft_dir = "community/cloud-foundation"


### PR DESCRIPTION
I think the pipeline examples should use the official repository address.