### PR TITLE
added os-login metadata to lustre deployment

### DIFF
--- a/community/lustre/lustre.jinja
+++ b/community/lustre/lustre.jinja
@@ -169,6 +169,8 @@ resources:
         - key: startup-script
           value: |
             {{ imports["scripts/startup-script.sh"]|indent(12)|replace("@CLUSTER_NAME@",properties["cluster_name"])|replace("@FS_NAME@",properties["fs_name"])|replace("@LUSTRE_VERSION@",properties["lustre_version"])|replace("@E2FS_VERSION@",properties["e2fs_version"])|replace("@NODE_ROLE@","MDS") }}
+        - key: enable-oslogin
+          value: "TRUE"
 {% endfor %}
 
 # Create N OSS nodes


### PR DESCRIPTION
We had trouble writing to and ls'ing the mounted lustre fs from the lustre clients (slurm cluster). We would get 'permission denied' when writing or ls'ing, and when using 'sudo ls -all /mnt/lustre' all of the permissions would show as question marks. After adding enable-oslogin all commands are behaving as expected. 