### PR TITLE
Add template for specifying an address with Compute globalAddress

### DIFF
--- a/google/resource-snippets/compute-v1/global_address.jinja
+++ b/google/resource-snippets/compute-v1/global_address.jinja
@@ -19,10 +19,10 @@ resources:
   {% if "address" in properties %}
     address: {{ properties["address"] }}
   {% endif %}
-    {% if "addressType" in properties %}
+  {% if "addressType" in properties %}
     addressType: {{ properties["addressType"] }}
   {% endif %}
-    {% if "network" in properties %}
+  {% if "network" in properties %}
     network: {{ properties["network"] }}
   {% endif %}
   {% if "prefixLength" in properties %}

--- a/google/resource-snippets/compute-v1/global_address_with_specific_address.yaml
+++ b/google/resource-snippets/compute-v1/global_address_with_specific_address.yaml
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+imports:
+- path: global_address.jinja
+
 resources:
-- type: gcp-types/compute-v1:globalAddresses
-  name: globaladdress-{{ env["deployment"] }}
+- name: globaladdress
+  type: global_address.jinja
   properties:
-  {% if "address" in properties %}
-    address: {{ properties["address"] }}
-  {% endif %}
-    {% if "addressType" in properties %}
-    addressType: {{ properties["addressType"] }}
-  {% endif %}
-    {% if "network" in properties %}
-    network: {{ properties["network"] }}
-  {% endif %}
-  {% if "prefixLength" in properties %}
-    prefixLength: {{ properties["prefixLength"] }}
-  {% endif %}
-  {% if "purpose" in properties %}
-    purpose: {{ properties["purpose"] }}
-  {% endif %}
+    address: 10.118.64.0
+    prefixLength: 20
+    addressType: INTERNAL
+    purpose: VPC_PEERING
+    network: DEFAULT_NETWORK


### PR DESCRIPTION
Support for this was recently fixed within deployment manager, therefore we wanted to add this to our public-facing examples. All of the fields being added to the Jinja template are optional in the default case, leading to a lot of conditionals in the template.

The new YAML file has been fully tested against DM as it exists today and is working as intended.