### PR TITLE
Update enum values for BigQuery dataset location

### DIFF
--- a/community/cloud-foundation/templates/bigquery/bigquery_dataset.py.schema
+++ b/community/cloud-foundation/templates/bigquery/bigquery_dataset.py.schema
@@ -38,9 +38,22 @@ properties:
       https://cloud.google.com/bigquery/docs/dataset-locations.
     default: 'US'
     enum:
-      - Asia
       - EU
       - US
+      - asia-east2
+      - asia-south1
+      - asia-northeast2
+      - asia-east1
+      - asia-northeast1
+      - asia-southeast1
+      - australia-southeast1
+      - europe-north1
+      - europe-west2
+      - europe-west6
+      - us-west2
+      - northamerica-northeast1
+      - us-east4
+      - southamerica-east1
   access:
     type: array
     description: |


### PR DESCRIPTION
I've aligned the enum values for BigQuery dataset location with the values defined in https://cloud.google.com/bigquery/docs/locations. I've added a bunch of regional locations but also removed Asia as this is no longer a valid value. This can be seen from the error response below:

```
ERROR: (gcloud.deployment-manager.deployments.create) Error in Operation [operation-1559562795381-58a6a026c74b5-2b665e25-36a38bfb]: errors:
- code: RESOURCE_ERROR
  location: /deployments/enterprise-006/resources/ENTERPRISE
  message: '{"ResourceType":"bigquery.v2.dataset","ResourceErrorCode":"400","ResourceErrorMessage":{"code":400,"errors":[{"domain":"global","message":"Invalid
    value for: Asia is not a valid value","reason":"invalid"}],"message":"Invalid
    value for: Asia is not a valid value","statusMessage":"Bad Request","requestPath":"https://www.googleapis.com/bigquery/v2/projects/tactical-hydra-999999/datasets","httpMethod":"POST"}}'
```