### PR TITLE
Fix "The reference 'masterAuth.clientKey' is not found" (#94)

### DIFF
--- a/community/cloud-foundation/templates/gke/gke.py
+++ b/community/cloud-foundation/templates/gke/gke.py
@@ -125,6 +125,10 @@ def generate_config(context):
         output_obj['name'] = outprop
         ma_props = ['clusterCaCertificate', 'clientCertificate', 'clientKey']
         if outprop in ma_props:
+            if outprop in ['clientCertificate', 'clientKey']:
+                if not properties.get('cluster',{}).get('masterAuth',{}).get(
+                           'clientCertificateConfig',{}).get('issueClientCertificate'):
+                    continue
             output_obj['value'] = '$(ref.' + name + \
                 '.masterAuth.' + outprop + ')'
         elif outprop == 'instanceGroupUrls':


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/94

Only output "clientCertificate" and "clientKey" when users specify "issueClientCertificate" True.