### PR TITLE
Add subscription expiration policy to Pub/Sub template

### DIFF
--- a/community/cloud-foundation/templates/pubsub/pubsub.py
+++ b/community/cloud-foundation/templates/pubsub/pubsub.py
@@ -35,6 +35,10 @@ def create_subscription(resource_name, spec, topic_resource_name, spec_index):
     if ack_deadline_seconds is not None:
         subscription['properties']['ackDeadlineSeconds'] = ack_deadline_seconds
 
+    expiration_policy = spec.get('expirationPolicy')
+    if expiration_policy is not None:
+        subscription['properties']['expirationPolicy'] = expiration_policy
+
     set_access_control(subscription, spec)
 
     return subscription

--- a/community/cloud-foundation/templates/pubsub/pubsub.py.schema
+++ b/community/cloud-foundation/templates/pubsub/pubsub.py.schema
@@ -44,6 +44,18 @@ properties:
             The maximum time to acknowledge a message receipt before retry.
           minimum: 10
           maximum: 600
+        expirationPolicy:
+          type: object
+          description: |
+            A policy that specifies the conditions for this subscription's expiration.
+          required:
+            - ttl
+          properties:
+            ttl:
+              type: string
+              description: |
+                Time-to-live duration in seconds. The subscription expires if it is not active
+                for a period of ttl.
         accessControl:
           type: array
           description: |

--- a/community/cloud-foundation/templates/pubsub/tests/integration/pubsub.bats
+++ b/community/cloud-foundation/templates/pubsub/tests/integration/pubsub.bats
@@ -96,6 +96,13 @@ function teardown() {
 @test "Verifying that second-subscription-${RAND}'s ackDeadlineSeconds was set" {
     run gcloud pubsub subscriptions describe second-subscription-${RAND} \
         --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+    [[ "$output" =~ "ackDeadlineSeconds: 15" ]]
+}
+
+@test "Verifying that second-subscription-${RAND}'s expiration policy was set" {
+    run gcloud pubsub subscriptions describe second-subscription-${RAND} \
+        --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+    [[ "$output" =~ "expirationPolicy:" ]]
     [[ "$output" =~ "ttl: 86400s" ]]
 }
 

--- a/community/cloud-foundation/templates/pubsub/tests/integration/pubsub.bats
+++ b/community/cloud-foundation/templates/pubsub/tests/integration/pubsub.bats
@@ -96,7 +96,7 @@ function teardown() {
 @test "Verifying that second-subscription-${RAND}'s ackDeadlineSeconds was set" {
     run gcloud pubsub subscriptions describe second-subscription-${RAND} \
         --project "${CLOUD_FOUNDATION_PROJECT_ID}"
-    [[ "$output" =~ "ackDeadlineSeconds: 15" ]]
+    [[ "$output" =~ "ttl: 86400s" ]]
 }
 
 @test "Deleting deployment" {

--- a/community/cloud-foundation/templates/pubsub/tests/integration/pubsub.yaml
+++ b/community/cloud-foundation/templates/pubsub/tests/integration/pubsub.yaml
@@ -24,3 +24,5 @@ resources:
                 - user:demo@user.com
         - name: second-subscription-${RAND}
           ackDeadlineSeconds: 15
+          expirationPolicy:
+            ttl: 86400s


### PR DESCRIPTION
By default Pub/Sub subscriptions expire after 31 days of inactivity. With this PR it is possible to overwrite the default duration. 