### PR TITLE
Fix folders reference name

### DIFF
--- a/community/cloud-foundation/templates/folder/folder.py.schema
+++ b/community/cloud-foundation/templates/folder/folder.py.schema
@@ -59,7 +59,7 @@ outputs:
       items:
         description: |
           The name of the folder resource. For example, the output can be
-          referenced as: $(ref.<my-folder>.rules.<folder-name>.parent)
+          referenced as: $(ref.<my-folder>.folders.<folder-name>.parent)
         patternProperties:
           ".*":
             type: object


### PR DESCRIPTION
The name of the output is folders neither rules.
https://github.com/GoogleCloudPlatform/deploymentmanager-samples/blob/0c1aee3ed67740c96fb29c7b0506c126c7230e19/community/cloud-foundation/templates/folder/folder.py#L51