### PR TITLE
Allow any bucket policy to be used for usage export bucket

### DIFF
--- a/community/cloud-foundation/templates/project/project.py
+++ b/community/cloud-foundation/templates/project/project.py
@@ -166,6 +166,7 @@ def create_shared_vpc_subnet_iam(context, dependencies, members_list):
     """ Grant the shared VPC subnet IAM permissions to Service Accounts. """
 
     resources = []
+    dependencies.append('api-compute.googleapis.com')
     if (
             context.properties.get('sharedVPCSubnets') and
             context.properties.get('sharedVPC')

--- a/community/cloud-foundation/templates/project/project.py
+++ b/community/cloud-foundation/templates/project/project.py
@@ -276,17 +276,19 @@ def create_bucket(properties):
     resources = []
     if properties.get('usageExportBucket'):
         bucket_name = '$(ref.project.projectId)-usage-export'
-
+        # The following allows any bucket policy to be set on the export
+        # bucket, while also overwritting any change to name/ project.
+        policy = properties.get('usageExportBucketPolicy')
+        if not policy:
+            policy = {}
+        policy['name'] = bucket_name
+        policy['project'] = '$(ref.project.projectId)'
         # Create the bucket.
         resources.append(
             {
                 'name': 'create-usage-export-bucket',
                 'type': 'gcp-types/storage-v1:buckets',
-                'properties':
-                    {
-                        'project': '$(ref.project.projectId)',
-                        'name': bucket_name
-                    },
+                'properties': policy,
                 'metadata':
                     {
                         'dependsOn': ['api-storage-component.googleapis.com']

--- a/community/cloud-foundation/templates/project/project.py
+++ b/community/cloud-foundation/templates/project/project.py
@@ -275,14 +275,13 @@ def create_bucket(properties):
 
     resources = []
     if properties.get('usageExportBucket'):
-        bucket_name = '$(ref.project.projectId)-usage-export'
         # The following allows any bucket policy to be set on the export
-        # bucket, while also overwritting any change to name/ project.
-        policy = properties.get('usageExportBucketPolicy')
-        if not policy:
-            policy = {}
-        policy['name'] = bucket_name
-        policy['project'] = '$(ref.project.projectId)'
+        # bucket. This allows specifying a bucket in another project.
+        policy = properties.get('usageExportBucketPolicy',{})
+        if 'name' not in policy.keys():
+            policy['name'] = '$(ref.project.projectId)-usage-export'
+        if 'project' not in policy.keys():
+            policy['project'] = '$(ref.project.projectId)'
         # Create the bucket.
         resources.append(
             {

--- a/community/cloud-foundation/templates/project/project.py.schema
+++ b/community/cloud-foundation/templates/project/project.py.schema
@@ -79,6 +79,8 @@ properties:
       Defines a bucket policy based on 
       https://cloud.google.com/storage/docs/json_api/v1/buckets/insert
       This is useful for setting ACLs, region or StorageClass.
+      If usageExportBucket is not set or set to false this setting will
+      be ignored.
   serviceAccounts:
     type: array
     default: []

--- a/community/cloud-foundation/templates/project/project.py.schema
+++ b/community/cloud-foundation/templates/project/project.py.schema
@@ -73,6 +73,12 @@ properties:
       False by default so as to not inadvertently incur
       costs to the user. It is strongly suggested to be enabled
       (set to True).
+  usageExportBucketPolicy:
+    type: object
+    description: |
+      Defines a bucket policy based on 
+      https://cloud.google.com/storage/docs/json_api/v1/buckets/insert
+      This is useful for setting ACLs, region or StorageClass.
   serviceAccounts:
     type: array
     default: []


### PR DESCRIPTION
This allows a dictionary to be passed as the bucket policy, allowing for any policy to be used, or any bucket for that matter. Continues using the defaults if usageExportBucket is not set.