### PR TITLE
Changing the container image

### DIFF
--- a/examples/v2/common/container_manifest.yaml
+++ b/examples/v2/common/container_manifest.yaml
@@ -21,8 +21,7 @@ metadata:
 spec:
   containers:
     - name: simple-echo
-      image: gcr.io/google-containers/busybox
-      command: ['nc', '-p', '8080', '-l', '-l', '-e', 'echo', 'hello world!']
+      image: gcr.io/google-samples/hello-app:2.0
       imagePullPolicy: Always
       ports:
         - containerPort: 8080


### PR DESCRIPTION
'nc -e' is deprecated, and potentially a security hole. The K8s hello app works just as well for our tutorials.