### PR TITLE
Fixes + cleanups for quickstart

### DIFF
--- a/quickstart.md
+++ b/quickstart.md
@@ -1,8 +1,10 @@
 # Deployment Manager Quickstart
 
-To restart this tutorial, in the Cloud Shell terminal, type:
+To restart this tutorial, run this command in the Cloud Shell terminal:
 
-	teachme ~/deploymentmanager-samples/quickstart.md
+```sh
+teachme ~/deploymentmanager-samples/quickstart.md
+```
 
 ## Introduction
 
@@ -23,22 +25,32 @@ comfortable running commands in a Linux terminal.
 
 ## Setting up
 
-1. Select or create a Cloud Platform project, [from
-	the Manage Resources page](https://console.cloud.google.com/cloud-resource-manager).
+1. Select or create a Google Cloud Platform project:
+
+    <walkthrough-project-setup></walkthrough-project-setup>
 
 1. [Enable billing](https://support.google.com/cloud/answer/6293499#enable-billing).
 
-1. [Enable the Deployment Manager and Compute
-	APIs](https://console.cloud.google.com/flows/enableapi?apiid=deploymentmanager,compute_component).
+1. Configure the `gcloud` command-line tool to use your project:
 
-1. Configure the `gcloud` command-line tool to use your project.
-   In Cloud Shell, type the following command, and replace `[MY_PROJECT]` with your project ID.
-	
-		gcloud config set project [MY_PROJECT]
+    ```sh
+	gcloud config set project {{project-id}}
+    ```
+
+1. Run this command to enable the Deployment Manager and Compute APIs:
+
+    ```sh
+    gcloud services enable compute.googleapis.com deploymentmanager.googleapis.com  
+    ```
 
 ## Define your resources
 
-To begin, <walkthrough-editor-open-file filePath="/deploymentmanager-samples/examples/v2/quick_start/vm.yaml">open the quickstart configuration in vm.yaml</walkthrough-editor-open-file>.
+To begin, run these commands to open the quickstart configuration in `vm.yaml`:
+
+```sh
+cd ~/deploymentmanager-samples/examples/v2/quick_start/
+cloudshell edit vm.yaml
+```
 
 This basic configuration file describes a deployment that contains one
 virtual machine instance with the following properties:
@@ -49,30 +61,26 @@ virtual machine instance with the following properties:
 + Root persistent disk: `boot`
 + A randomly assigned external IP address
 
-In the configuration file, replace these placeholders:
-
-* `[MY_PROJECT]` with your project ID
-* `[FAMILY_NAME]` with the image family `debian-9`
-* `[IMAGE_PROJECT]` with `debian-cloud`.
+In the configuration file, replace `[MY_PROJECT]` with your project ID.
  
 To save your changes, from the **File** menu, click **Save**.
 
 ## Deploy the resources
 
-In your Cloud Shell, navigate to the `quick_start` folder:
-
-    cd ~/deploymentmanager-samples/examples/v2/quick_start
-
 To deploy your resources, use the `gcloud` command-line tool to create a new
 deployment, using your configuration file:
 
-    gcloud deployment-manager deployments create quickstart-deployment --config vm.yaml
+```sh
+gcloud deployment-manager deployments create quickstart-deployment --config vm.yaml
+```
 
 ## Check on your deployment
 
-To check the status of the deployment, run the following command:
+To check the status of the deployment, run this command:
 
-    gcloud deployment-manager deployments describe quickstart-deployment
+```sh
+gcloud deployment-manager deployments describe quickstart-deployment
+```
 
 ## Review your resources
 
@@ -80,7 +88,7 @@ After you have created the deployment, you can review your resources in the
 Cloud console.
 
 1. To see a list of your deployments,
-    [open the Deployment Manager page in the console](https://console.cloud.google.com/dm/deployments).
+    [open the Deployment Manager page](https://console.cloud.google.com/dm/deployments).
 
 1. To see the resources in the deployment, click **quickstart-deployment**. The
    deployment overview opens, with information about the deployment, and the
@@ -93,7 +101,9 @@ Cloud console.
 To avoid incurring charges on your Cloud Platform account, delete the deployment and
 all the resources that you created:
 
-	gcloud deployment-manager deployments delete quickstart-deployment
+```sh
+gcloud deployment-manager deployments delete quickstart-deployment
+```
 
 ## What's next
 


### PR DESCRIPTION
1. Set up project from within the quickstart.
2. Fix broken link to vm.yaml
3. Updated to match the current state of the sample.
4. Misc. formatting and things