### PR TITLE
Add multi mdt support and multiple ost per oss

### DIFF
--- a/community/lustre/lustre-template.yaml
+++ b/community/lustre/lustre-template.yaml
@@ -37,20 +37,22 @@ resources:
     e2fs_version            : < E2FSPROGS version;              latest;         OPTIONAL >
 
     ## MDS/MGS Configuration
-    mds_node_count          : < Num Lustre MDS instances;       1;              OPTIONAL >
-    mds_ip_address          : < MDS IP Address range start;     10.20.0.2;      OPTIONAL >
+    mds_node_count          : < Num Lustre MDS instances;       1 >
+    mds_ip_range_start      : < MDS IP Address range start;     10.20.0.1;      OPTIONAL >
     mds_machine_type        : < MDS instance profile;           n1-standard-16; OPTIONAL >
     mds_boot_disk_type      : < MDS Boot Disk Type;             pd-standard;    OPTIONAL >
     mds_boot_disk_size_gb   : < MDS Boot Disk Size (GB);        40;             OPTIONAL >
+    mdt_per_mds             : < Num Lustre MDT per MDS;         1 >
     mdt_disk_type           : < Metadata Target Disk Type;      pd-ssd >
     mdt_disk_size_gb        : < MDT Disk Size (GB);             500 >
 
     ## OSS Configuration
     oss_node_count          : < Num Lustre OSS instances;           4 >
-    oss_ip_range_start      : < OSS IP Address range start;     10.20.0.5;      OPTIONAL >
+    oss_ip_range_start      : < OSS IP Address range start;     10.20.0.50;      OPTIONAL >
     oss_machine_type        : < OSS instance profile;           n1-standard-16; OPTIONAL >
     oss_boot_disk_type      : < OSS Boot Disk Type;             pd-standard;    OPTIONAL >
     oss_boot_disk_size_gb   : < OSS Boot Disk Size (GB);        100;            OPTIONAL >
+    ost_per_mdt             : < Num Lustre OST per OSS;         1 >
     ost_disk_type           : < OST Disk Type;                  pd-ssd >
     ost_disk_size_gb        : < OST Disk Size (GB);             100 >
     #  [END cluster_yaml]

--- a/community/lustre/lustre.jinja
+++ b/community/lustre/lustre.jinja
@@ -116,20 +116,22 @@ resources:
         {% set num_mdt_local_ssds = 8 %}
     {% endif %}
     {% for i in range(num_mdt_local_ssds) %}
-    - type: SCRATCH
-      autoDelete: true
-      interface: NVME
-      initializeParams:
-        diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["mdt_disk_type"] }}
+      - type: SCRATCH
+        autoDelete: true
+        interface: NVME
+        initializeParams:
+          diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["mdt_disk_type"] }}
     {% endfor %}
     {% else %}
-    - deviceName: mdt
+    {% for i in range(properties ["mdt_per_mds"]) %}
+    - deviceName: mdt-{{ i + 1 }}
       type: PERSISTENT
       autoDelete: true
       initializeParams:
-        diskName: {{properties["cluster_name"]}}-mdt{{ n + 1 }}
+        diskName: {{properties["cluster_name"]}}-mdt{{ n + 1 }}-{{ i + 1 }}
         diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["mdt_disk_type"] }}
         diskSizeGb: {{ properties["mdt_disk_size_gb"] }}
+    {% endfor %}
     {% endif %}
 {% if not properties['external_ips'] %}
     canIpForward: true
@@ -150,14 +152,12 @@ resources:
         type: ONE_TO_ONE_NAT
   {% endif %}
 # If the MDS IP is specified, use that
-{% if properties["mds_ip_address"] %}
-      networkIP: {{ properties["mds_ip_address"] }}
-# If no MDS IP is specified, use DHCP
-# This code used to hardcode the MDS IP as X.X.X.2
-#{% else %}
-#{% set mds_ip = subnet_split[0] ~ '.' ~ subnet_split[1] ~ '.' ~ subnet_split[2] ~ '.2' %}
-#      networkIP: {{ mds_ip }}
-{% endif %}
+{% if properties['mds_ip_range_start'] %}
+{% set mds_ip_split = properties['mds_ip_range_start'].split('.')[3] | int %}
+{% set mds_ip_uniq = mds_ip_split + n %}
+{% set mds_ip = subnet_split[0] ~ '.' ~ subnet_split[1] ~ '.' ~ subnet_split[2] ~ '.' ~ mds_ip_uniq %}
+      networkIP: {{ mds_ip }}
+ {% endif %}
     serviceAccounts:
       - email: "default"
         scopes:
@@ -168,7 +168,7 @@ resources:
       items:
         - key: startup-script
           value: |
-            {{ imports["scripts/startup-script.sh"]|indent(12)|replace("@CLUSTER_NAME@",properties["cluster_name"])|replace("@FS_NAME@",properties["fs_name"])|replace("@LUSTRE_VERSION@",properties["lustre_version"])|replace("@E2FS_VERSION@",properties["e2fs_version"])|replace("@NODE_ROLE@","MDS") }}
+            {{ imports["scripts/startup-script.sh"]|indent(12)|replace("@CLUSTER_NAME@",properties["cluster_name"])|replace("@FS_NAME@",properties["fs_name"])|replace("@LUSTRE_VERSION@",properties["lustre_version"])|replace("@E2FS_VERSION@",properties["e2fs_version"])|replace("@NODE_ROLE@","MDS")|replace("@MDT_PER_MDS@",properties["mdt_per_mds"])|replace("@OST_PER_OSS@",properties["ost_per_oss"]) }}
 {% endfor %}
 
 # Create N OSS nodes
@@ -200,13 +200,15 @@ resources:
         diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["ost_disk_type"] }}
     {% endfor %}
     {% else %}
-    - deviceName: ost
+    {% for i in range(properties ["ost_per_oss"]) %}
+    - deviceName: ost-{{ i + 1 }}
       type: PERSISTENT
       autoDelete: true
       initializeParams:
-        diskName: {{properties["cluster_name"]}}-ost{{ n + 1 }}
+        diskName: {{properties["cluster_name"]}}-ost{{ n + 1 }}-{{ i + 1 }}
         diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["ost_disk_type"] }}
         diskSizeGb: {{ properties["ost_disk_size_gb"] }}
+    {% endfor %}
     {% endif %}
   {% if (properties ['vpc_subnet'] and properties ['vpc_net'] and properties ['shared_vpc_host_proj'])  %}
     networkInterfaces:
@@ -229,10 +231,6 @@ resources:
 {% set oss_ip_uniq = oss_ip_split + n %}
 {% set oss_ip = subnet_split[0] ~ '.' ~ subnet_split[1] ~ '.' ~ subnet_split[2] ~ '.' ~ oss_ip_uniq %}
       networkIP: {{ oss_ip }}
-#{% else %}
-#{% set oss_ip_uniq = n + 3 %}
-#{% set oss_ip = subnet_split[0] ~ '.' ~ subnet_split[1] ~ '.' ~ subnet_split[2] ~ '.' ~ oss_ip_uniq %}
-#      networkIP: {{ oss_ip }}
 {% endif %}
     serviceAccounts:
       - email: "default"
@@ -242,5 +240,5 @@ resources:
       items:
         - key: startup-script
           value: |
-            {{ imports["scripts/startup-script.sh"]|indent(12)|replace("@CLUSTER_NAME@",properties["cluster_name"])|replace("@FS_NAME@",properties["fs_name"])|replace("@LUSTRE_VERSION@",properties["lustre_version"])|replace("@E2FS_VERSION@",properties["e2fs_version"])|replace("@NODE_ROLE@","OSS") }}
+            {{ imports["scripts/startup-script.sh"]|indent(12)|replace("@CLUSTER_NAME@",properties["cluster_name"])|replace("@FS_NAME@",properties["fs_name"])|replace("@LUSTRE_VERSION@",properties["lustre_version"])|replace("@E2FS_VERSION@",properties["e2fs_version"])|replace("@NODE_ROLE@","OSS")|replace("@OST_PER_OSS@",properties["ost_per_oss"])|replace("@MDT_PER_MDS@",properties["mdt_per_mds"])  }}
 {% endfor %}

--- a/community/lustre/lustre.jinja.schema
+++ b/community/lustre/lustre.jinja.schema
@@ -26,10 +26,14 @@ required:
 - zone
 - cidr
 - oss_node_count
+- mds_ip_range_start
 - mds_boot_disk_type
 - mds_boot_disk_size_gb
+- mdt_per_mds
 - mdt_disk_size_gb
 - mdt_disk_type
+- oss_ip_range_start
+- ost_per_oss
 - ost_disk_size_gb
 - ost_disk_type
 - external_ips
@@ -45,7 +49,6 @@ optional:
 - mds_machine_type
 #- mgs_machine_type
 - mds_ip_address
-- oss_ip_range_start
 - vpc_net
 - vpc_subnet
 - shared_vpc_host_proj
@@ -62,6 +65,10 @@ properties:
   oss_ip_range_start:
     type        : string
     description : IP address range start for the OSS nodes.
+
+  mds_ip_range_start:
+    type        : string
+    description : IP address range start for the MDS nodes.
 
   cluster_name:
     type        : string
@@ -150,6 +157,16 @@ properties:
   oss_node_count:
     type        : integer
     description : Number of OSS node instances to run.
+
+  mdt_per_mds:
+    type        : integer
+    default     : 1
+    description : Number of MDT disks per MDS instance.
+
+  ost_per_oss:
+    type        : integer
+    default     : 1
+    description : Number of OST disk per OSS instances.
 
   zone:
     type        : string

--- a/community/lustre/lustre.yaml
+++ b/community/lustre/lustre.yaml
@@ -37,24 +37,27 @@ resources:
     e2fs_version            : latest
 
     ## Lustre MDS/MGS Node Configuration
-    #mds_node_count          : 1
-    mds_ip_address          : 10.20.0.2
+    ## The mds1 will assume the mgs role
+    mds_node_count          : 2
+    mds_ip_range_start      : 10.20.0.2
     mds_machine_type        : n1-standard-32
     ### MDS/MGS Boot disk
     mds_boot_disk_type      : pd-standard
     mds_boot_disk_size_gb   : 10
     ### Lustre MetaData Target disk
+    mdt_per_mds             : 1
     mdt_disk_type           : pd-ssd
     mdt_disk_size_gb        : 100
 
     ## Lustre OSS Configuration
     oss_node_count          : 4
-    oss_ip_range_start      : 10.20.0.5
+    oss_ip_range_start      : 10.20.0.50
     oss_machine_type        : n1-standard-16
     ### OSS Boot disk
     oss_boot_disk_type      : pd-standard
     oss_boot_disk_size_gb   : 10
     ### Lustre Object Storage Target disk
+    ost_per_oss             : 2
     ost_disk_type           : pd-standard
     ost_disk_size_gb        : 1000
     #  [END cluster_yaml]

--- a/community/lustre/scripts/startup-script.sh
+++ b/community/lustre/scripts/startup-script.sh
@@ -21,6 +21,8 @@ FS_NAME="@FS_NAME@"
 NODE_ROLE="@NODE_ROLE@"
 ost_mount_point="/mnt/ost"
 mdt_mount_point="/mnt/mdt"
+mdt_per_mds="@MDT_PER_MDS@"
+ost_per_oss="@OST_PER_OSS@"
 
 LUSTRE_VERSION="@LUSTRE_VERSION@"
 LUSTRE_URL="https://downloads.whamcloud.com/public/lustre/${LUSTRE_VERSION}/el7/server/RPMS/x86_64/"
@@ -149,25 +151,32 @@ function main() {
 			while [ `sudo lctl ping ${CLUSTER_NAME}-oss1 | grep -c "Input/output error"` -gt 0 ]; do
 				sleep 10
 			done
-
-			# Make the MDT mount and mount the device
-			mkdir $mdt_mount_point
-			mkfs.lustre --mdt --mgs --index=${host_index} --fsname=${FS_NAME} --mgsnode=${MDS_HOSTNAME} $lustre_device
-			echo "$lustre_device	$mdt_mount_point	lustre" >> /etc/fstab
-			mount -a
-
-			# Once the network is up, make the lustre filesystem on the MDT
-			#mkfs.lustre --mdt --mgs --index=${host_index} --fsname=${FS_NAME} --mgsnode=${MDS_HOSTNAME} /dev/sdb
-
-			# Make the MDT mount and mount the device
-			#mkdir /mdt
-			#mount -t lustre /dev/sdb /mdt
 			
-			# Check for a successful mount, and fail otherwise.
-			if [ `mount | grep -c $mdt_mount_point` -eq 0 ]; then
-				echo "MDT mount has failed. Please try mounting manually with "mount -t lustre $lustre_device $mdt_mount_point", or reboot this node."
-				exit 1
-			fi
+			let host_index=$host_index*$mdt_per_mds
+			i=0
+			for lustre_device in $(ls /dev/sd* | grep -v sda[0-9]*$ ); do
+			
+				# Make the MDT mount and mount the device
+			        let host_index=host_index+i
+				mkdir $mdt_mount_point$i
+				if [[ "$MDS_HOSTNAME" == $(hostname) && ${host_index} == 0 ]]; then
+					# Create the first mdt as the mgs of the cluster
+					mkfs.lustre --mdt --mgs --index=${host_index} --fsname=${FS_NAME} --mgsnode=${MDS_HOSTNAME} $lustre_device
+				else
+					mkfs.lustre --mdt --index=${host_index} --fsname=${FS_NAME} --mgsnode=${MDS_HOSTNAME} $lustre_device
+					# Sleep 60 seconds to give MGS time to come up 
+					sleep 60
+				fi
+				echo "$lustre_device	$mdt_mount_point$i	lustre" >> /etc/fstab
+				mount -a
+			
+				# Check for a successful mount, and fail otherwise.
+				if [ `mount | grep -c $mdt_mount_point` -eq 0 ]; then
+					echo "MDT mount has failed. Please try mounting manually with "mount -t lustre $lustre_device $mdt_mount_point", or reboot this node."
+					exit 1
+				fi
+				let i=i+1
+			done
 
 			# Disable the authentication upcall by default, change if using auth
 			echo NONE > /proc/fs/lustre/mdt/lustre-MDT0000/identity_upcall
@@ -182,17 +191,24 @@ function main() {
 			# Sleep 60 seconds to give MDS/MGS time to come up before the OSS. More robust communication would be good.
 			sleep 60
 
-			# Make the directory to mount the OST, and mount the OST
-			mkdir $ost_mount_point
-			mkfs.lustre --ost --index=${host_index} --fsname=${FS_NAME} --mgsnode=${MDS_HOSTNAME} $lustre_device
-			echo "$lustre_device	$ost_mount_point	lustre" >> /etc/fstab
-			mount -a
-			
-			# Check for a successful mount, and fail otherwise.
-			if [ `mount | grep -c $ost_mount_point` -eq 0 ]; then
-				echo "OST mount has failed. Please try mounting manually with \"mount -t lustre $lustre_device $ost_mount_point\", or reboot this node."
-				exit 1
-			fi
+			let host_index=host_index*ost_per_oss
+			echo "OST_PER_OSS = $ost_per_oss" >> /lustre/install.log
+			i=0
+			for lustre_device in $(ls /dev/sd* | grep -v sda[0-9]*$ ); do
+				# Make the directory to mount the OST, and mount the OST
+				let host_index=host_index+i
+				mkdir $ost_mount_point$i
+				mkfs.lustre --ost --index=${host_index} --fsname=${FS_NAME} --mgsnode=${MDS_HOSTNAME} $lustre_device
+				echo "$lustre_device	$ost_mount_point$i	lustre" >> /etc/fstab
+				mount -a
+				
+				# Check for a successful mount, and fail otherwise.
+				if [ `mount | grep -c $ost_mount_point$i` -eq 0 ]; then
+					echo "OST mount has failed. Please try mounting manually with \"mount -t lustre $lustre_device $ost_mount_point$i\", or reboot this node." >> /lustre/install.log
+					exit 1
+				fi
+				let i=i+1
+			done
 		fi
 		# Mark install.log as reaching stage 2
 		echo 2 > /lustre/install.log


### PR DESCRIPTION
This PR should provide an increase of the metadata performance on a Lustre Filesystem on two different ways: 

- 1 MDS : N MTDs: Setting up multiple MDTs on the same MDS will increase the IOPS and avoid communication overhead between MDSs.
- N MDS : M MDTs:  With multiple MDTs on several MDS we could increase the number of IOPS and also the amount of RPCs processed per second. 

It also allows to increase the number of OSTs without adding more OSS in oder to be able to increase the stripe count on the filesystem underneath without increasing the total cost of the solution.