### PR TITLE
Add sample configs for new compute resources

### DIFF
--- a/google/resource-snippets/compute-v1/external-vpn-gateway.jinja
+++ b/google/resource-snippets/compute-v1/external-vpn-gateway.jinja
@@ -1,0 +1,22 @@
+# Copyright 2019 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- name: external-vpn-gateway-{{ env["deployment"] }}
+  type: gcp-types/compute-v1:externalVpnGateways
+  properties:
+    redundancyType: SINGLE_IP_INTERNALLY_REDUNDANT
+    interfaces:
+     - id: 0
+       ipAddress: 192.168.0.0

--- a/google/resource-snippets/compute-v1/external-vpn-gateway.yaml
+++ b/google/resource-snippets/compute-v1/external-vpn-gateway.yaml
@@ -1,0 +1,20 @@
+# Copyright 2019 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: external-vpn-gateway.jinja
+
+resources:
+- name: external-vpn-gateway
+  type: external-vpn-gateway.jinja

--- a/google/resource-snippets/compute-v1/vpn-gateway.jinja
+++ b/google/resource-snippets/compute-v1/vpn-gateway.jinja
@@ -1,0 +1,26 @@
+# Copyright 2019 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+- type: gcp-types/compute-v1:networks
+  name: network-{{ env["deployment"] }}
+  properties:
+    routingConfig:
+      routingMode: REGIONAL
+    autoCreateSubnetworks: true
+- type: gcp-types/compute-v1:vpnGateways
+  name: gateway-{{ env["deployment"] }}
+  properties:
+    region: {{ properties["region"] }}
+    network: $(ref.network-{{ env["deployment"] }}.selfLink)

--- a/google/resource-snippets/compute-v1/vpn-gateway.yaml
+++ b/google/resource-snippets/compute-v1/vpn-gateway.yaml
@@ -1,0 +1,22 @@
+# Copyright 2019 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: vpn-gateway.jinja
+
+resources:
+- name: vpn-gateway
+  type: vpn-gateway.jinja
+  properties:
+    region: REGION_TO_RUN


### PR DESCRIPTION
Deployment Manager recently released support for Compute Engine's [VpnGateway](https://cloud.google.com/compute/docs/reference/rest/v1/vpnGateways) and [ExternalVpnGateway](https://cloud.google.com/compute/docs/reference/rest/v1/externalVpnGateways) collections. This adds some basic templates demonstrating how they can be used.