### PR TITLE
Fix network initialization for HTCondor example

### DIFF
--- a/examples/v2/htcondor/startup-compute-centos.sh
+++ b/examples/v2/htcondor/startup-compute-centos.sh
@@ -14,7 +14,7 @@ else
 fi
 CONDOR_REPO_URL=https://research.cs.wisc.edu/htcondor/yum/repo.d/htcondor-stable-rhel${OS_VERSION}.repo
 
-sleep 2 #Give it some time to setup yum
+while ! ping -c1 google.com >/dev/null; do sleep 1 ; done
 cd /tmp
 yum install -y wget curl net-tools vim
 wget https://research.cs.wisc.edu/htcondor/yum/RPM-GPG-KEY-HTCondor

--- a/examples/v2/htcondor/startup-compute-debian.sh
+++ b/examples/v2/htcondor/startup-compute-debian.sh
@@ -7,6 +7,7 @@ else
 fi
 
 cd /tmp
+while ! ping -c1 google.com >/dev/null; do sleep 1 ; done
 apt-get update && apt-get install -y wget curl net-tools vim
 echo "deb http://research.cs.wisc.edu/htcondor/debian/stable/ jessie contrib" >> /etc/apt/sources.list
 wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -

--- a/examples/v2/htcondor/startup-master-centos.sh
+++ b/examples/v2/htcondor/startup-master-centos.sh
@@ -14,7 +14,7 @@ else
 fi
 CONDOR_REPO_URL=https://research.cs.wisc.edu/htcondor/yum/repo.d/htcondor-stable-rhel${OS_VERSION}.repo
 
-sleep 2 #Give it some time to setup yum
+while ! ping -c1 google.com >/dev/null; do sleep 1 ; done
 cd /tmp
 yum install -y wget curl net-tools vim
 wget https://research.cs.wisc.edu/htcondor/yum/RPM-GPG-KEY-HTCondor

--- a/examples/v2/htcondor/startup-master-debian.sh
+++ b/examples/v2/htcondor/startup-master-debian.sh
@@ -7,6 +7,7 @@ else
 fi
 
 cd /tmp
+while ! ping -c1 google.com >/dev/null; do sleep 1 ; done
 apt-get update && apt-get install -y wget curl net-tools vim
 echo "deb http://research.cs.wisc.edu/htcondor/debian/stable/ jessie contrib" >> /etc/apt/sources.list
 wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -

--- a/examples/v2/htcondor/startup-submit-centos.sh
+++ b/examples/v2/htcondor/startup-submit-centos.sh
@@ -15,7 +15,7 @@ fi
 CONDOR_REPO_URL=https://research.cs.wisc.edu/htcondor/yum/repo.d/htcondor-stable-rhel${OS_VERSION}.repo
 
 # Install utilities and condor and configure it
-sleep 2 #Give some time to setup yum info
+while ! ping -c1 google.com >/dev/null; do sleep 1 ; done
 cd /tmp
 yum install -y wget curl net-tools vim gcc
 wget https://research.cs.wisc.edu/htcondor/yum/RPM-GPG-KEY-HTCondor

--- a/examples/v2/htcondor/startup-submit-debian.sh
+++ b/examples/v2/htcondor/startup-submit-debian.sh
@@ -7,6 +7,7 @@ else
 fi
 
 cd /tmp
+while ! ping -c1 google.com >/dev/null; do sleep 1 ; done
 apt-get update && apt-get install -y wget net-tools vim curl gcc
 echo "deb http://research.cs.wisc.edu/htcondor/debian/stable/ jessie contrib" >> /etc/apt/sources.list
 wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -


### PR DESCRIPTION
These scripts were sometimes breaking on GCE because the hardcoded sleep was not enough to set up the network before downloading packages. Both Debian and CentOS seem to be working consistently after this change. 

example log line from CentOS instance Stackdriver:
"Nov 25 15:18:05 condor-submit startup-script: INFO startup-script:  One of the configured repositories failed (Unknown)," 