### PR TITLE
Add BigQuery range partitioning + Move partition filter to table-level properties

### DIFF
--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py
@@ -36,6 +36,7 @@ def generate_config(context):
         'expirationTime',
         'schema',
         'timePartitioning',
+        'clustering',
         'view'
     ]
 

--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py
@@ -36,6 +36,7 @@ def generate_config(context):
         'expirationTime',
         'schema',
         'timePartitioning',
+        'rangePartitioning',
         'clustering',
         'view'
     ]

--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py
@@ -38,6 +38,7 @@ def generate_config(context):
         'timePartitioning',
         'rangePartitioning',
         'clustering',
+        'requirePartitionFilter',
         'view'
     ]
 

--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
@@ -74,6 +74,19 @@ properties:
         description: |
           The only supported type is DAY, which generates one partition
           per day.
+  clustering:
+    type: object
+    description: The clustering specification for this table.
+    properties:
+      fields:
+        type: array
+        description: |
+          One or more fields on which data should be clustered.
+          Only top-level, non-repeated, simple-type fields are supported.
+          The order of the fields will determine how clusters
+          will be generated, so it is important.
+        items:
+          type: string
   view:
     type: object
     description: The view definintion.

--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
@@ -67,6 +67,7 @@ properties:
       requirePartitionFilter:
         type: boolean
         description: |
+          DEPRECATED. Please set the field with the same name on the table itself.
           If True, queries over the table require a partition filter
           (that can be used for partition elimination) to be specified.
       type:
@@ -112,6 +113,11 @@ properties:
           will be generated, so it is important.
         items:
           type: string
+  requirePartitionFilter:
+    type: boolean
+    description: |
+      Optional. If set to true, queries over this table require a partition filter 
+      that can be used for partition elimination to be specified.
   view:
     type: object
     description: The view definintion.

--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
@@ -74,6 +74,31 @@ properties:
         description: |
           The only supported type is DAY, which generates one partition
           per day.
+  rangePartitioning:
+    type: object
+    description: The range-based partitioning specification for this table.
+    properties:
+      field:
+        type: string
+        description: |
+          Required. Experimental. The table is partitioned by this field. 
+          The field must be a top-level NULLABLE/REQUIRED field. 
+          The only supported type is INTEGER/INT64.
+      range:
+        type: object
+        properties:
+          start:
+            type: string
+            description: |
+              Required. Experimental. The start of range partitioning, inclusive.
+          end:
+            type: string
+            description: |
+              Required. Experimental. The end of range partitioning, exclusive.
+          interval:
+            type: string
+            description: |
+              Required. Experimental. The width of each interval.
   clustering:
     type: object
     description: The clustering specification for this table.


### PR DESCRIPTION
1. Add BigQuery range partitioning
2. Move partition filter to table-level properties hence it is deprecated on time partitioning level