### PR TITLE
Fix Cloud Function sample

### DIFF
--- a/examples/v2/cloud_functions/python/cloud_function.py
+++ b/examples/v2/cloud_functions/python/cloud_function.py
@@ -35,7 +35,7 @@ def GenerateConfig(ctx):
   m.update(content)
   source_archive_url = 'gs://%s/%s' % (ctx.properties['codeBucket'],
                                        m.hexdigest() + '.zip')
-  cmd = "echo '%s' | base64 -d > /function/function.zip;" % (content)
+  cmd = "echo '%s' | base64 -d > /function/function.zip;" % (content.decode('ascii'))
   volumes = [{'name': 'function-code', 'path': '/function'}]
   build_step = {
       'name': 'upload-function-code',


### PR DESCRIPTION
The base-64 encoding generates a binary output which is then rendered
as b'...' into the echo command. This causes the deployment to fail.
Instead, decode the base-64 encoded binary data as ascii string.