### PR TITLE
Update container_helper.py to include missing parentheses in the for loop

### DIFF
--- a/examples/v2/ha-service/container_helper.py
+++ b/examples/v2/ha-service/container_helper.py
@@ -16,7 +16,7 @@ def GenerateManifest(context):
   """
   env_list = []
   if 'dockerEnv' in context.properties:
-    for key, value in six.iteritems(context.properties['dockerEnv']:
+    for key, value in six.iteritems(context.properties['dockerEnv']):
       env_list.append({'name': key, 'value': str(value)})
 
   manifest = {


### PR DESCRIPTION
The for loop did not have a parentheses at the end, which caused deployment manager to fail.