### PR TITLE
Add function url to cloud_function templalte outputs

### DIFF
--- a/examples/v2/cloud_functions/python/cloud_function.py
+++ b/examples/v2/cloud_functions/python/cloud_function.py
@@ -103,5 +103,8 @@ def GenerateConfig(ctx):
       }, {
           'name': 'name',
           'value': '$(ref.' + function_name + '.name)'
+      }, {
+          'name': 'url',
+          'value': '$(ref.' + function_name + '.httpsTrigger.url)'
       }]
   }

--- a/examples/v2/cloud_functions/python/cloud_function.yaml
+++ b/examples/v2/cloud_functions/python/cloud_function.yaml
@@ -33,3 +33,5 @@ outputs:
   value: $(ref.function-call.result)
 - name: function-code
   value: $(ref.function.sourceArchiveUrl)
+- name: function-url
+  value: $(ref.function.url)


### PR DESCRIPTION
While it's simple enough to `describe` the function later, it is helpful to simply include the function URL in the template outputs.

Example result:

```
OUTPUTS          VALUE
function-output  {"hello":"world","time":"2020-02-09T16:12:42.253Z","codeHash":"b70b788b5dd0af98ba801b3eb60975a9"}
function-code    gs://playground-deploy-artifacts/b70b788b5dd0af98ba801b3eb60975a9.zip
function-url     https://us-central1-playground-252414.cloudfunctions.net/deploy-functioncf
```