### PR TITLE
Use function-call request data in cloud function output

### DIFF
--- a/examples/v2/cloud_functions/python/cloud_function.yaml
+++ b/examples/v2/cloud_functions/python/cloud_function.yaml
@@ -23,7 +23,7 @@ resources:
     name: $(ref.function.name)
     data: |
       {
-        "hola": "mundo"
+        "message": "hola, mundo"
       }
   metadata:
     runtimePolicy:

--- a/examples/v2/cloud_functions/python/function/index.js
+++ b/examples/v2/cloud_functions/python/function/index.js
@@ -5,7 +5,8 @@
  * @param {Object} res Cloud Function response context.
  */
 exports.handler = function(req, res) {
-  console.log(req.body.message);
+  const { message } = req.body;
+  console.log(message);
   res.status(200).send(
-      {hello: 'world', time: new Date(), codeHash: process.env.codeHash});
+      {hello: 'world', message, time: new Date(), codeHash: process.env.codeHash});
 };


### PR DESCRIPTION
The function log did not match the function_call data. Change the function_call data to match the function's expectation, and also use this value in the function's return value to more visibly demonstrate the connections between the resource and the function.