### PR TITLE
BigQuery: Move partition filter to table-level properties

### DIFF
--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py
@@ -36,7 +36,6 @@ def generate_config(context):
         'expirationTime',
         'schema',
         'timePartitioning',
-        'rangePartitioning',
         'clustering',
         'requirePartitionFilter',
         'view'

--- a/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
+++ b/community/cloud-foundation/templates/bigquery/bigquery_table.py.schema
@@ -75,31 +75,6 @@ properties:
         description: |
           The only supported type is DAY, which generates one partition
           per day.
-  rangePartitioning:
-    type: object
-    description: The range-based partitioning specification for this table.
-    properties:
-      field:
-        type: string
-        description: |
-          Required. Experimental. The table is partitioned by this field. 
-          The field must be a top-level NULLABLE/REQUIRED field. 
-          The only supported type is INTEGER/INT64.
-      range:
-        type: object
-        properties:
-          start:
-            type: string
-            description: |
-              Required. Experimental. The start of range partitioning, inclusive.
-          end:
-            type: string
-            description: |
-              Required. Experimental. The end of range partitioning, exclusive.
-          interval:
-            type: string
-            description: |
-              Required. Experimental. The width of each interval.
   clustering:
     type: object
     description: The clustering specification for this table.


### PR DESCRIPTION
Move partition filter to table-level properties hence it is deprecated on time partitioning level

https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TimePartitioning