### PR TITLE
Move gke type provider to openapi v2

### DIFF
--- a/google/resource-snippets/container-v1/gke_provider_cluster.jinja
+++ b/google/resource-snippets/container-v1/gke_provider_cluster.jinja
@@ -67,7 +67,7 @@ resources:
 - name: {{ env["deployment"] }}-gke-type
   type: deploymentmanager.local.typeProvider
   properties:
-    descriptorUrl: https://$(ref.{{ env["deployment"] }}.endpoint)/swaggerapi/api/v1
+    descriptorUrl: https://$(ref.{{ env["deployment"] }}.endpoint)/openapi/v2
     options:
       validationOptions:
         schemaValidation: IGNORE_WITH_WARNINGS
@@ -79,7 +79,7 @@ resources:
 - name: {{ env["deployment"] }}-gke-type-extensions
   type: deploymentmanager.local.typeProvider
   properties:
-    descriptorUrl: https://$(ref.{{ env["deployment"] }}.endpoint)/swaggerapi/apis/extensions/v1beta1
+    descriptorUrl: https://$(ref.{{ env["deployment"] }}.endpoint)/openapi/v2
     options:
       validationOptions:
         schemaValidation: IGNORE_WITH_WARNINGS


### PR DESCRIPTION
GKE now defaults to version 1.14: https://cloud.google.com/kubernetes-engine/docs/release-notes, where swagger endpoint has been removed.

Updating GKE-based type providers to use openapi/v2 instead. Extensions have been merged into /openapi/v2 so updating both type providers to same endpoint for backwards compatibility, longer term we can merge usages into single provider.