### PR TITLE
Fix Cloud SQL sample

### DIFF
--- a/examples/v2/cloudsql/cloudsql.jinja
+++ b/examples/v2/cloudsql/cloudsql.jinja
@@ -50,7 +50,7 @@ resources:
       backupConfiguration:
         enabled: true
         binaryLogEnabled: true
-        startTime: {{ properties['cloudsql']['backupStartTime'] }}
+        startTime: "{{ properties['cloudsql']['backupStartTime'] }}"
       ipConfiguration:
         authorizedNetworks: {{ properties['cloudsql']['authorizedNetworks'] }}
 


### PR DESCRIPTION
Clock time in the format xx:yy needs to be quoted in order to avoid the YAML parser interpreting it as a sexagesimal number.