### PR TITLE
add openapi/v2 support to gke/python sample code

### DIFF
--- a/examples/v2/gke/README.md
+++ b/examples/v2/gke/README.md
@@ -109,6 +109,6 @@ From a second session, you may then browse or:
 
 When deploying into a Kubernetes cluster with Deployment Manager, it is
 important to be aware that deleting `Deployment` Kubernetes objects
-**does not delete the underlying pods**, and it is your responsibility to
+**may not delete the underlying pods**, and it is your responsibility to
 manage the destruction of these resources when deleting a
 `Deployment` in your configuration.

--- a/examples/v2/gke/python/cluster.py.schema
+++ b/examples/v2/gke/python/cluster.py.schema
@@ -37,9 +37,3 @@ outputs:
   clusterType:
     description: The name of the type provider which can create resources from the Kubernetes v1 API in your cluster.
     type: string
-  clusterType-apps:
-    description: The name of the type provider which can create resources from the Kubernetes apps/v1beta1 API in your cluster.
-    type: string
-  clusterType-v1beta1-extensions:
-    description: The name of the type provider which can create resources from the Kubernetes v1beta1-extensions API in your cluster.
-    type: string

--- a/examples/v2/gke/python/deployment.py
+++ b/examples/v2/gke/python/deployment.py
@@ -15,86 +15,73 @@
 
 
 def GenerateConfig(context):
-  """Generate YAML resource configuration."""
+    """Generate YAML resource configuration."""
 
-  cluster_types_root = ''.join([
-      context.env['project'],
-      '/',
-      context.properties['clusterType']
-      ])
-  cluster_types = {
-      'Service': ''.join([
-          cluster_types_root,
-          ':',
-          '/api/v1/namespaces/{namespace}/services'
-          ]),
-      'Deployment': ''.join([
-          cluster_types_root,
-          '-apps',
-          ':',
-          '/apis/apps/v1beta1/namespaces/{namespace}/deployments'
-          ])
-  }
+    cluster_types_root = ''.join([context.env['project'], '/', context.properties['clusterType']])
+    cluster_types = {
+        'Service': ''.join([cluster_types_root, ':', '/api/v1/namespaces/{namespace}/services/{name}']),
+        'Deployment': ''.join([cluster_types_root, ':', '/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}'])
+    }
 
-  name_prefix = context.env['deployment'] + '-' + context.env['name']
-  port = context.properties['port']
+    name_prefix = context.env['deployment'] + '-' + context.env['name']
+    port = context.properties['port']
 
-  resources = [{
-      'name': name_prefix + '-service',
-      'type': cluster_types['Service'],
-      'properties': {
-          'apiVersion': 'v1',
-          'kind': 'Service',
-          'namespace': 'default',
-          'metadata': {
-              'name': name_prefix + '-service',
-              'labels': {
-                  'id': 'deployment-manager'
-              }
-          },
-          'spec': {
-              'type': 'NodePort',
-              'ports': [{
-                  'port': port,
-                  'targetPort': port,
-                  'protocol': 'TCP'
-              }],
-              'selector': {
-                  'app': name_prefix
-              }
-          }
-      }
-  }, {
-      'name': name_prefix + '-deployment',
-      'type': cluster_types['Deployment'],
-      'properties': {
-          'apiVersion': 'apps/v1beta1',
-          'kind': 'Deployment',
-          'namespace': 'default',
-          'metadata': {
-              'name': name_prefix + '-deployment'
-          },
-          'spec': {
-              'replicas': 1,
-              'template': {
-                  'metadata': {
-                      'labels': {
-                          'name': name_prefix + '-deployment',
-                          'app': name_prefix
-                      }
-                  },
-                  'spec': {
-                      'containers': [{
-                          'name': 'container',
-                          'image': context.properties['image'],
-                          'ports': [{
-                              'containerPort': port
-                          }]
-                      }]
-                  }
-              }
-          }
-      }
-  }]
+    resources = [{
+        'name': name_prefix + '-service',
+        'type': cluster_types['Service'],
+        'properties': {
+            'apiVersion': 'v1',
+            'kind': 'Service',
+            'metadata': {
+                'name': name_prefix + '-service',
+                'namespace': 'default',
+                'labels': {
+                    'id': 'deployment-manager'
+                }
+            },
+            'spec': {
+                'type': 'NodePort',
+                'ports': [{
+                    'port': port,
+                    'targetPort': port,
+                    'protocol': 'TCP'
+                }],
+                'selector': {
+                    'app': name_prefix
+                }
+            }
+        }
+    }, {
+        'name': name_prefix + '-deployment',
+        'type': cluster_types['Deployment'],
+        'properties': {
+            'apiVersion': 'apps/v1beta1',
+            'kind': 'Deployment',
+            'metadata': {
+                'name': name_prefix + '-deployment',
+                'namespace': 'default'
+            },
+            'spec': {
+                'replicas': 1,
+                'template': {
+                    'metadata': {
+                        'labels': {
+                            'name': name_prefix + '-deployment',
+                            'app': name_prefix
+                        }
+                    },
+                    'spec': {
+                        'containers': [{
+                            'name': 'container',
+                            'image': context.properties['image'],
+                            'ports': [{
+                                'containerPort': port
+                            }]
+                        }]
+                    }
+                }
+            }
+        }
+    }]
 
-  return {'resources': resources}
+    return {'resources': resources}


### PR DESCRIPTION
Sample code for the following files wasn't working after the move to openapi/v2: 
- cluster.py
- cluster.schema
- deployment.py

This update helps folks new to `deployment-manager` at least get a _hello-world_ going.

This code works after refactor:
```
# DEPLOY THE CLUSTER
$ gcloud deployment-manager deployments create ingernet --template cluster.py --properties zone:$ZONE
The fingerprint of the deployment is o3UIihCshClYWmcZCgwrcA==
Waiting for create [operation-1583425714879-5a01e07437c54-9a198cf2-650426d5]...done.          
Create operation operation-1583425714879-5a01e07437c54-9a198cf2-650426d5 completed successfully.
NAME                      TYPE                                   STATE      ERRORS  INTENT
ingernet-cluster-py       container.v1.cluster                   COMPLETED  []
ingernet-cluster-py-type  deploymentmanager.v2beta.typeProvider  COMPLETED  []

# DEPLOY THE DEPLOYMENT
$ gcloud deployment-manager deployments create ${NAME}-web --template deployment.py \
> --properties clusterType:${NAME}-cluster-py-type,image:${IMAGE},port:${PORT}
The fingerprint of the deployment is cuBGZETtHX7AHd3MeJTcmw==
Waiting for create [operation-1583426395133-5a01e2fcf578e-817735f2-1c6f1eb3]...done.          
Create operation operation-1583426395133-5a01e2fcf578e-817735f2-1c6f1eb3 completed successfully.
NAME                                   TYPE                           STATE      ERRORS  INTENT
ingernet-web-deployment-py-deployment  <REDACTED-PROJECT>/ingernet-clu  COMPLETED  []
                                       ster-py-type:/apis/apps/v1bet
                                       a1/namespaces/{namespace}/dep
                                       loyments/{name}
ingernet-web-deployment-py-service    <REDACTED-PROJECT>/ingernet-clu  COMPLETED  []
                                       ster-py-type:/api/v1/namespac
                                       es/{namespace}/services/{name
                                       }

# GET CREDENTIALS
$ gcloud container clusters get-credentials ${NAME}-cluster-py --zone ${ZONE}
Fetching cluster endpoint and auth data.
kubeconfig entry generated for ingernet-cluster-py.

# LOOK FOR DEPLOYMENTS AND SERVICES
$ kubectl get deployments
NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
ingernet-web-deployment-py-deployment   1/1     1            1           55s

$ kubectl get services
NAME                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
ingernet-web-deployment-py-service   NodePort    <REDACTED-IP>   <none>        80:32709/TCP   66s
kubernetes                           ClusterIP   <REDACTED-CLUSTER-IP>     <none>        443/TCP        9m59s

# FIRE UP PORT FORWARDING
$ kubectl port-forward $(\
>   kubectl get pods --output=jsonpath="{.items[0].metadata.name}") \
>   9999:${PORT}
Forwarding from 127.0.0.1:9999 -> 80
Forwarding from [::1]:9999 -> 80

# IN A NEW WINDOW, CURL localhost:9999
$ curl http://localhost:9999
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
...SNIP...

# IN THAT SAME NEW WINDOW, SET UP YOUR ENV VARIABLES
$NODES=$(kubectl get nodes --output=name | sed 's|node/||g')
$NODE_HOST=$(shuf -n1 -e ${NODES})
$ NODE_PORT=$(\
>   kubectl get services \
>   --selector=id=deployment-manager \
>   --output=jsonpath="{.items[0].spec.ports[0].nodePort}")

# ALSO IN THE NEW WINDOW, SSH INTO THE NODE
# (i had to specify the zone in my command because it was different from the profile i was using)
$ gcloud compute ssh ${NODE_HOST} --ssh-flag="-L ${NODE_PORT}:localhost:${NODE_PORT}" --zone=us-central1-b
Warning: Permanently added 'compute.1740778203171821088' (ED25519) to the list of known hosts.

Welcome to Kubernetes v1.14.10-gke.17!
...SNIP...
```