### PR TITLE
Change Lustre boot disk size

### DIFF
--- a/community/lustre/lustre-template.yaml
+++ b/community/lustre/lustre-template.yaml
@@ -57,6 +57,8 @@ resources:
     ## Lustre HSM Lemur Configuration
     hsm_node_count          : < Num Lustre HSM Data Mover instances;    1;             OPTIONAL >
     hsm_machine_type        : < HSM instance profile;                   n1-standard-8; OPTIONAL >
+    hsm_boot_disk_type      : < HSM Boot Disk Type;                     pd-standard;   OPTIONAL >
+    hsm_boot_disk_size_gb   : < HSM Boot Disk Size (GB);                100;           OPTIONAL >
     hsm_gcs_bucket          : < HSM Archive bucket;                     ;              OPTIONAL >
     hsm_gcs_bucket_import   : < GCS Bucket path to import data from;    ;              OPTIONAL >
     #  [END cluster_yaml]

--- a/community/lustre/lustre.jinja
+++ b/community/lustre/lustre.jinja
@@ -1,11 +1,11 @@
 # Copyright 2019 Google LLC
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/community/lustre/lustre.jinja
+++ b/community/lustre/lustre.jinja
@@ -261,8 +261,8 @@ resources:
       autoDelete: true
       initializeParams:
         sourceImage: https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7
-        diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/pd-standard
-        diskSizeGb: 20
+        diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/{{ properties["hsm_boot_disk_type"] }}
+        diskSizeGb: {{ properties["hsm_boot_disk_size_gb"] }}
   {% if (properties ['vpc_subnet'] and properties ['vpc_net'] and properties ['shared_vpc_host_proj'])  %}
     networkInterfaces:
     - subnetwork: https://www.googleapis.com/compute/v1/projects/{{ properties["shared_vpc_host_proj"] }}/regions/{{ region_ext }}/subnetworks/{{ properties ["vpc_subnet"] }}

--- a/community/lustre/lustre.jinja.schema
+++ b/community/lustre/lustre.jinja.schema
@@ -51,6 +51,8 @@ optional:
 - shared_vpc_host_proj
 - hsm_node_count
 - hsm_machine_type
+- hsm_boot_disk_type
+- hsm_boot_disk_size_gb
 - gcs_bucket_import
 
 properties:
@@ -184,6 +186,18 @@ properties:
     type        : string
     default     : n1-standard-8
     description : Machine type to use for Lustre HSM Data Movers node instances, eg. n1-standard-4.
+
+  hsm_boot_disk_type:
+    enum        : ["pd-ssd", "pd-standard"]
+    default     : pd-standard
+    description : Disk type (pd-ssd or pd-standard) for HSM boot disk.
+
+  hsm_boot_disk_size_gb:
+    type        : integer
+    default     : 20
+    minimum     : 20
+    maximum     : 64000
+    description : Size of disk for the HSM boot disk.
 
   hsm_gcs_bucket:
     type        : string

--- a/community/lustre/lustre.jinja.schema
+++ b/community/lustre/lustre.jinja.schema
@@ -82,13 +82,13 @@ properties:
 
   mds_machine_type:
     type        : string
-    default     : n1-standard-8 
+    default     : n1-standard-8
     description : |
       Machine type to use for MDS node instances, eg. n1-standard-4.
 
   oss_machine_type:
     type        : string
-    default     : n1-standard-8 
+    default     : n1-standard-8
     description : |
       Machine type to use for OSS node instances, eg. n1-standard-4.
 
@@ -100,7 +100,7 @@ properties:
   mds_boot_disk_size_gb:
     type        : integer
     default     : 100
-    minimum     : 10
+    minimum     : 20
     maximum     : 64000
     description : Size of disk for the MDS boot disk.
 
@@ -124,7 +124,7 @@ properties:
   oss_boot_disk_size_gb:
     type        : integer
     default     : 100
-    minimum     : 10
+    minimum     : 20
     maximum     : 64000
     description : Size of disk for the OSS boot disk.
 

--- a/community/lustre/lustre.yaml
+++ b/community/lustre/lustre.yaml
@@ -61,6 +61,9 @@ resources:
     ## Lustre HSM Lemur Configuration
     #hsm_node_count         : 1
     #hsm_machine_type       : n1-standard-8
+    ### HSM Boot Disk
+    #hsm_boot_disk_type     : pd-standard
+    #hsm_boot_disk_size_gb  : 20
     #hsm_gcs_bucket         : [MY_BUCKET]
     #hsm_gcs_bucket_import  : [MY_BUCKET_PATH]
     #  [END cluster_yaml]


### PR DESCRIPTION
Change Lustre boot disk size to 20 GB following CentOS base image size change