### PR TITLE
Update GKE type and schema with loggingService property

### DIFF
--- a/google/resource-snippets/container-v1/gke_provider_cluster.jinja
+++ b/google/resource-snippets/container-v1/gke_provider_cluster.jinja
@@ -29,6 +29,9 @@ resources:
       {% if properties["monitoringService"] %}
       monitoringService: {{ properties["monitoringService"] }}
       {% endif %}
+      {% if properties["loggingService"] %}
+      loggingService: {{ properties["loggingService"] }}
+      {% endif %}
       {% if properties["httpLoadBalancing"] is defined %}
       addonsConfig:
         httpLoadBalancing:

--- a/google/resource-snippets/container-v1/gke_provider_cluster.jinja.schema
+++ b/google/resource-snippets/container-v1/gke_provider_cluster.jinja.schema
@@ -47,8 +47,12 @@ properties:
     default: false
   monitoringService:
     type: string
-    description: What monitoring service to use. Can be
-      monitoring.googleapis.com (API default) or none.
+    description: What monitoring service to use. Can be monitoring.googleapis.com/kubernetes (API default)
+      or monitoring.googleapis.com (< GKE 1.15) or none.
+  loggingService:
+    type: string
+    description: What logging service to use. Can be logging.googleapis.com/kubernetes (API default)
+      or logging.googleapis.com (< GKE 1.15) or none.
   httpLoadBalancing:
     type: boolean
     description: If false, httpLoadBalancing is disabled. If not set, no

--- a/google/resource-snippets/container-v1beta1/gke_provider_cluster.yaml
+++ b/google/resource-snippets/container-v1beta1/gke_provider_cluster.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 imports:
 - path: ../container-v1/gke_provider_cluster.jinja
 


### PR DESCRIPTION
Updating GKE type template and schema with `loggingService` property. Added copy-right header to `container-v1beta1/gke_provider_cluster.yaml`