### PR TITLE
Remove reference to a resource that no longer exists in kms.jinja

### DIFF
--- a/google/resource-snippets/cloudkms-v1/kms.jinja
+++ b/google/resource-snippets/cloudkms-v1/kms.jinja
@@ -38,10 +38,3 @@ resources:
   properties:
     parent: $(ref.cryptoKey.name)
 {% endif %}
-- name: dummy
-  type: DUMMY_V1_RESOURCE
-  properties:
-    duration: 0,0
-    kind: $(ref.decrypt.plaintext.base64Decode().load().locations[0].name)
-    name: indirect-{{ env["deployment"] }}
-    project: {{ env["project"] }}


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/deploymentmanager-samples/pull/566 deleted DM resources that used `action:`. But `kms.jinja` still references one of the deleted resources (`$(ref.decrypt)`), so this invalid reference should be deleted.