### PR TITLE
Additional inputMappings for better GKE management.

### DIFF
--- a/google/resource-snippets/container-v1/gke_provider_cluster.jinja
+++ b/google/resource-snippets/container-v1/gke_provider_cluster.jinja
@@ -86,5 +86,21 @@ resources:
         location: HEADER
         value: >
           $.concat("Bearer ", $.googleOauth2AccessToken())
+      - fieldName: metadata.resourceVersion
+        location: BODY
+        methodMatch: ^(put|patch)$
+        value: $.resource.self.metadata.resourceVersion
+      - fieldName: id
+        location: PATH
+        methodMatch: ^(put|get|delete|post|patch)$
+        value: $.resource.properties.id
+      - fieldName: name
+        location: PATH
+        methodMatch: ^(put|get|delete|post|patch)$
+        value: $.resource.properties.metadata.name
+      - fieldName: namespace
+        location: PATH
+        methodMatch: ^(put|get|delete|post|patch)$
+        value: $.resource.properties.namespace
     customCertificateAuthorityRoots:
     - $(ref.{{env["deployment"]}}.masterAuth.clusterCaCertificate)


### PR DESCRIPTION
*  `metadata.resourceversion` is required on all updates, so without it you cannot edit deployments using this type provider after initial provisioning.
*   The remainder are descriptions of how to find `PATH` components from the resource.