### PR TITLE
Use `iamMemmberBinding` in TPU example

### DIFF
--- a/google/resource-snippets/tpu-v1alpha1/tpu.yaml
+++ b/google/resource-snippets/tpu-v1alpha1/tpu.yaml
@@ -5,12 +5,13 @@ resources:
 - name: tpu
   type: tpu.py
   properties:
-    zone: ZONE_TO_RUN
+    zone: SPECIFY_ZONE
     acceleratorType: v2-8
-    tensorflowVersion: "1.8"
+    tensorflowVersion: "2.3"
     cidrBlock: 10.27.101.0/29
     # If network is not present it will default to `default`
-    network: tpu-network
+    network: SPECIFY_NETWORK
+    
     # If bucket is specified, the service account created with the TPU node
     # will be granted access to the bucket here.
-    gcsBucket: tpu-integ-test-bucket
+    gcsBucket: SPECIFY_BUCKET


### PR DESCRIPTION
Replaced actions-based IAM policy management with virtual bindings. Deployed the config in a test project, made sure that bucket got the TPU service account added.