### PR TITLE
Add example to read Cloud Runtime Configuration

### DIFF
--- a/community/sqladmin/secret-password/REAME.md
+++ b/community/sqladmin/secret-password/REAME.md
@@ -1,0 +1,39 @@
+# Cloud SQL Example
+
+## Avoid keep passwords on yaml files
+
+It differs from the [cloudsql example](https://github.com/GoogleCloudPlatform/deploymentmanager-samples/tree/master/examples/v2/cloudsql)
+by not storing the user password into the yaml file. It uses a
+[runtame configurator](https://cloud.google.com/deployment-manager/runtime-configurator)
+variable to store it.
+
+This allows to commit the yaml file to a git repository without
+the password on plain text on it.
+
+## Setup
+
+- create a config
+
+```
+gcloud beta runtime-config configs example-cloudsql-config
+```
+- create the variable containing the password
+
+```
+gcloud beta runtime-config configs variables set \
+    username/root \
+    "secret" \
+    --config-name example-cloudsql-config \
+    --is-text
+```
+
+
+## More information
+
+[Cloud SQL Documentation](https://cloud.google.com/sql/docs/)
+
+[Creating and Deleting RuntimeConfig Resources](https://cloud.google.com/deployment-manager/runtime-configurator/create-and-delete-runtimeconfig-resources)
+
+[Cloud Runtime Configuration API](https://cloud.google.com/deployment-manager/runtime-configurator/reference/rest)
+
+[gcloud beta runtime-config](https://cloud.google.com/sdk/gcloud/reference/beta/runtime-config)

--- a/community/sqladmin/secret-password/cloudsql.py
+++ b/community/sqladmin/secret-password/cloudsql.py
@@ -1,0 +1,78 @@
+def generate_config(context):
+    env = context.env
+    properties = context.properties
+
+    project = env['project']
+    ID = env['deployment'] + '-' + env['name']
+
+    read_password = {
+        'name': '{ID}-user-password'.format(ID=ID),
+        'action': (
+            'gcp-types/runtimeconfig-v1beta1:runtimeconfig.projects.configs.variables.get'
+        ),
+        'properties': {
+            'name': (
+                'projects/{project}/configs/{config_name}/variables/{pwd_name}'.format(
+                    project=project,
+                    config_name=properties['dbUser']['configName'],
+                    pwd_name=properties['dbUser']['passwordVariable'],
+                )
+            ),
+        },
+        'metadata': {
+            'runtimePolicy': ['UPDATE_ALWAYS'],
+        },
+    }
+
+    instance = {
+        'name': '{ID}-master'.format(ID=ID),
+        'type': 'sqladmin.v1beta4.instance',
+        'properties': {
+            'name': env['name'],
+            'databaseVersion': 'POSTGRES_12',
+            'settings': {
+                'tier': 'db-g1-small',
+                'storageAutoResize': True,
+            },
+        },
+    }
+
+    database = {
+        'name': '{ID}-db'.format(ID=ID),
+        'type': 'sqladmin.v1beta4.database',
+        'properties': {
+            'name': properties['dbUser']['user'],
+            'charset': 'utf8',
+            'instance': '$(ref.{}.name)'.format(
+                instance['name'],
+            ),
+        },
+    }
+
+    user = {
+        'name': '{ID}-db-user'.format(ID=ID),
+        'type': 'sqladmin.v1beta4.user',
+        'properties': {
+            'name': properties['dbUser']['user'],
+            'password': '$(ref.{}.text)'.format(
+                read_password['name'],
+            ),
+            'instance': '$(ref.{}.name)'.format(
+                instance['name'],
+            ),
+        },
+        'metadata': {
+            'dependsOn': [
+                database['name'],
+            ]
+        },
+    }
+
+    return {
+        "resources": [
+            read_password,
+            instance,
+            database,
+            user,
+        ],
+    }

--- a/community/sqladmin/secret-password/db.example.yaml
+++ b/community/sqladmin/secret-password/db.example.yaml
@@ -1,0 +1,10 @@
+imports:
+  - path: cloudsql.py
+resources:
+  - name: cloudsql
+    type: cloudsql.py
+    properties:
+      dbUser:
+        user: root
+        configName: example-cloudsql-config
+        passwordVariable: username/root


### PR DESCRIPTION
This example uses a pre-defined Runtime Configuration to
store the password (instead of keep it on yaml file).