### PR TITLE
Add autoCreateSubnetworks field to compute networks

### DIFF
--- a/google/resource-snippets/compute-v1/cloud_router.py
+++ b/google/resource-snippets/compute-v1/cloud_router.py
@@ -25,7 +25,9 @@ def GenerateConfig(context):
   region = properties['region']
   compute_resource_util.SetContext(context)
 
-  network = ComputeResource('network', compute_constants.NETWORKS, {})
+  network = ComputeResource('network', compute_constants.NETWORKS, {
+    'autoCreateSubnetworks': True
+  })
   vpn_gateway = ComputeResource('vpg', compute_constants.TARGETVPNGATEWAYS, {
       'network': network.SelfLink(),
       'region': region

--- a/google/resource-snippets/dns-v1beta2/dns_private.jinja
+++ b/google/resource-snippets/dns-v1beta2/dns_private.jinja
@@ -15,6 +15,8 @@
 resources:
 - name: network-1-{{ env["deployment"] }}
   type: gcp-types/compute-v1:networks
+  properties:
+    autoCreateSubnetworks: true
 - name: {{ properties["zoneName"] }}
   type: gcp-types/dns-{{ properties["version"] }}:managedZones
   properties:


### PR DESCRIPTION
In a couple of different configs we create a compute network in order to leverage it elsewhere. To do that, we need to set this field to `true`.