### PR TITLE
Adding KRM and TF alternatives for BigQuery snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,17 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Terraform files
+######################
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+*.tfvars
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/google/resource-snippets/bigquery-v2/README.md
+++ b/google/resource-snippets/bigquery-v2/README.md
@@ -1,0 +1,34 @@
+# Bigquery Snippets
+
+## DM
+
+```bash
+gcloud services enable deploymentmanager.googleapis.com
+gcloud deployment-manager deployments create d1 --config bigquery.yaml
+```
+
+## Terraform
+
+```bash
+TF_PROJECT_ID=[TF_PROJECT_ID]
+gcloud config set project $TF_PROJECT_ID
+cd tf
+terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+```
+
+## KRM
+
+```bash
+gcloud container clusters get-credentials [CLUSTER_ID] --zone=[ZONE]
+cd krm
+kpt cfg set . deployment d1
+kubectl apply -f bigquery.yaml
+```
+
+## Testing
+
+```bash
+cd alternatives
+sh test.sh
+```

--- a/google/resource-snippets/bigquery-v2/README.md
+++ b/google/resource-snippets/bigquery-v2/README.md
@@ -12,7 +12,7 @@ gcloud deployment-manager deployments create d1 --config bigquery.yaml
 ```bash
 TF_PROJECT_ID=[TF_PROJECT_ID]
 gcloud config set project $TF_PROJECT_ID
-cd tf
+cd alternatives/tf
 terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
 terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
 ```
@@ -21,7 +21,7 @@ terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT
 
 ```bash
 gcloud container clusters get-credentials [CLUSTER_ID] --zone=[ZONE]
-cd krm
+cd alternatives/krm
 kpt cfg set . deployment d1
 kubectl apply -f bigquery.yaml
 ```
@@ -29,6 +29,5 @@ kubectl apply -f bigquery.yaml
 ## Testing
 
 ```bash
-cd alternatives
-sh test.sh
+sh test_alternatives.sh
 ```

--- a/google/resource-snippets/bigquery-v2/README.md
+++ b/google/resource-snippets/bigquery-v2/README.md
@@ -2,22 +2,43 @@
 
 ## DM
 
+Setup:
+
+* Install [gcloud](https://cloud.google.com/sdk/docs/install)
+* Create GCP project
+
 ```bash
+DM_PROJECT_ID=[DM_PROJECT_ID]
+gcloud config set project $DM_PROJECT_ID
 gcloud services enable deploymentmanager.googleapis.com
 gcloud deployment-manager deployments create d1 --config bigquery.yaml
 ```
 
 ## Terraform
 
+Setup:
+
+* Install [gcloud](https://cloud.google.com/sdk/docs/install)
+* Install [terraform](https://www.terraform.io/downloads.html)
+* Create GCP project
+
 ```bash
 TF_PROJECT_ID=[TF_PROJECT_ID]
 gcloud config set project $TF_PROJECT_ID
 cd alternatives/tf
+terraform init
 terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
 terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
 ```
 
 ## KRM
+
+Setup:
+
+* Install [gcloud](https://cloud.google.com/sdk/docs/install)
+* Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+* Install [kpt](https://github.com/GoogleContainerTools/kpt#installation)
+* Create GCP project
 
 ```bash
 gcloud container clusters get-credentials [CLUSTER_ID] --zone=[ZONE]

--- a/google/resource-snippets/bigquery-v2/alternatives/krm/Kptfile
+++ b/google/resource-snippets/bigquery-v2/alternatives/krm/Kptfile
@@ -1,0 +1,31 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: bigquery
+packageMetadata:
+  shortDescription: configure bigquery
+openAPI:
+  definitions:
+    io.k8s.cli.setters.deployment:
+      x-k8s-cli:
+        setter:
+          name: deployment
+          value: ${DEPLOYMENT?}
+          setBy: PLACEHOLDER
+      description: deployment name
+    io.k8s.cli.substitutions.dataset-sub:
+      x-k8s-cli:
+        substitution:
+          name: deployment-sub
+          pattern: DEPLOYMENT_SETTERdataset
+          values:
+          - marker: DEPLOYMENT_SETTER
+            ref: '#/definitions/io.k8s.cli.setters.deployment'
+    io.k8s.cli.substitutions.table-sub:
+      x-k8s-cli:
+        substitution:
+          name: table-sub
+          pattern: DEPLOYMENT_SETTERtable
+          values:
+          - marker: DEPLOYMENT_SETTER
+            ref: '#/definitions/io.k8s.cli.setters.deployment'

--- a/google/resource-snippets/bigquery-v2/alternatives/krm/bigquery.yaml
+++ b/google/resource-snippets/bigquery-v2/alternatives/krm/bigquery.yaml
@@ -1,0 +1,16 @@
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryTable
+metadata:
+  name: ${DEPLOYMENT?}table # {"$ref":"#/definitions/io.k8s.cli.substitutions.table-sub"}
+  labels:
+      goog-dm: ${DEPLOYMENT?} # {"$ref":"#/definitions/io.k8s.cli.setters.deployment"}
+spec:
+  datasetRef:
+    name: ${DEPLOYMENT?}dataset # {"$ref":"#/definitions/io.k8s.cli.substitutions.dataset-sub"}
+---
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryDataset
+metadata:
+  name: ${DEPLOYMENT?}dataset # {"$ref":"#/definitions/io.k8s.cli.substitutions.dataset-sub"}
+  labels:
+    goog-dm: ${DEPLOYMENT?} # {"$ref":"#/definitions/io.k8s.cli.setters.deployment"}

--- a/google/resource-snippets/bigquery-v2/alternatives/test.sh
+++ b/google/resource-snippets/bigquery-v2/alternatives/test.sh
@@ -1,0 +1,69 @@
+set -e
+
+# assumes that the following projects are created and kubectl context is set to a cluster in KRM_PROJECT
+TF_PROJECT_ID=[TF_PROJECT_ID]
+KRM_PROJECT_ID=[KRM_PROJECT_ID]
+DM_PROJECT_ID=[DM_PROJECT_ID]
+
+# source ../../../../tools/alt-testing/create-projects.sh
+
+gcloud auth application-default login
+
+# Create DM resources
+pushd ../
+gcloud config set project $DM_PROJECT_ID
+gcloud services enable deploymentmanager.googleapis.com
+gcloud deployment-manager deployments create d1 --config bigquery.yaml
+popd
+
+# Create Terraform resources
+pushd tf
+gcloud config set project $TF_PROJECT_ID
+terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+popd
+
+# Create KCC resources
+cp -R krm krm_${KRM_PROJECT_ID}
+pushd krm_${KRM_PROJECT_ID}
+kpt cfg set . deployment d1
+kubectl apply -f bigquery.yaml
+kubectl  wait --for=condition=Ready BigQueryTable --all
+popd
+rm -rf krm_${KRM_PROJECT_ID}
+
+
+# Export DM and TF resources for comparison
+{ gcloud alpha bq datasets list --project=${DM_PROJECT_ID} --format=yaml && gcloud alpha bq tables list --dataset=d1dataset --project=${DM_PROJECT_ID} --format=yaml; } \
+    | sed "s/${DM_PROJECT_ID}/PROJECT/" | sed "s/creationTime: .*/creationTime: TIME/" \
+    > /tmp/${DM_PROJECT_ID}.yaml
+
+{ gcloud alpha bq datasets list --project=${TF_PROJECT_ID} --format=yaml && gcloud alpha bq tables list --dataset=d1dataset --project=${TF_PROJECT_ID} --format=yaml; } \
+    | sed "s/${TF_PROJECT_ID}/PROJECT/" | sed "s/creationTime: .*/creationTime: TIME/" \
+    > /tmp/${TF_PROJECT_ID}.yaml
+
+{ gcloud alpha bq datasets list --project=${KRM_PROJECT_ID} --format=yaml && gcloud alpha bq tables list --dataset=d1dataset --project=${KRM_PROJECT_ID} --format=yaml; } \
+    | sed "s/${KRM_PROJECT_ID}/PROJECT/" | sed "s/creationTime: .*/creationTime: TIME/" | sed "/cnrm-lease-.*/d" | sed "/managed-by-cnrm.*/d" \
+    > /tmp/${KRM_PROJECT_ID}.yaml
+
+# source ../../../../tools/alt-testing/delete-projects.sh
+
+diff /tmp/${TF_PROJECT_ID}.yaml /tmp/${DM_PROJECT_ID}.yaml
+
+if [[ $(diff /tmp/${TF_PROJECT_ID}.yaml /tmp/${DM_PROJECT_ID}.yaml) ]]; then
+    echo "TF and DM outputs are NOT identical"
+    exit 1
+else
+    echo "TF and DM outputs are identical"
+fi
+
+diff /tmp/${KRM_PROJECT_ID}.yaml /tmp/${DM_PROJECT_ID}.yaml
+
+if [[ $(diff /tmp/${KRM_PROJECT_ID}.yaml /tmp/${DM_PROJECT_ID}.yaml) ]]; then
+    echo "KRM and DM outputs are NOT identical"
+    exit 1
+else
+    echo "KRM and DM outputs are identical"
+fi
+
+exit 0

--- a/google/resource-snippets/bigquery-v2/alternatives/tf/bigquery.tf
+++ b/google/resource-snippets/bigquery-v2/alternatives/tf/bigquery.tf
@@ -1,0 +1,29 @@
+variable "deployment" {}
+variable "project_id" {}
+
+provider "google" {
+  project = var.project_id
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}
+
+locals{
+    DATASET = replace(format("%sdataset", var.deployment), "-", "_")
+    TABLE = replace(format("%stable", var.deployment), "-", "_")
+}
+
+resource "google_bigquery_dataset" "default" {
+  dataset_id = local.DATASET
+  labels = {
+    goog-dm = var.deployment
+  }
+}
+
+resource "google_bigquery_table" "default" {
+  dataset_id = google_bigquery_dataset.default.dataset_id
+  table_id   = local.TABLE
+  labels = {
+    goog-dm = var.deployment
+  }
+}
+

--- a/google/resource-snippets/bigquery-v2/bigquery.jinja
+++ b/google/resource-snippets/bigquery-v2/bigquery.jinja
@@ -17,8 +17,8 @@
 
 # Can't use deployment name as it is going to be filled in with a generated
 # name which has dashes in it, which are not valid bigquery name characters.
-{% set DATASET = (env["deployment"] + "-dataset")|replace("-","_") %}
-{% set TABLE = (env["deployment"] + "-table")|replace("-","_") %}
+{% set DATASET = (env["deployment"] + "dataset")|replace("-","_") %}
+{% set TABLE = (env["deployment"] + "table")|replace("-","_") %}
 
 resources:
 - name: {{ DATASET }}-test

--- a/google/resource-snippets/bigquery-v2/test_alternatives.sh
+++ b/google/resource-snippets/bigquery-v2/test_alternatives.sh
@@ -10,22 +10,20 @@ DM_PROJECT_ID=[DM_PROJECT_ID]
 gcloud auth application-default login
 
 # Create DM resources
-pushd ../
 gcloud config set project $DM_PROJECT_ID
 gcloud services enable deploymentmanager.googleapis.com
 gcloud deployment-manager deployments create d1 --config bigquery.yaml
-popd
 
 # Create Terraform resources
-pushd tf
+pushd alternatives/tf
 gcloud config set project $TF_PROJECT_ID
 terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
 terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
 popd
 
 # Create KCC resources
-cp -R krm krm_${KRM_PROJECT_ID}
-pushd krm_${KRM_PROJECT_ID}
+cp -R alternatives/krm /tmp/krm_${KRM_PROJECT_ID}
+pushd /tmp/krm_${KRM_PROJECT_ID}
 kpt cfg set . deployment d1
 kubectl apply -f bigquery.yaml
 kubectl  wait --for=condition=Ready BigQueryTable --all

--- a/tools/alt-testing/README.md
+++ b/tools/alt-testing/README.md
@@ -1,0 +1,4 @@
+# This directory contains the scripts that can be used for testing Terraform and config-connector alternatives
+
+* ./create-projects.sh script creates DM, TF and KCC projects and configures KCC cluster
+* ./delete-projects.sh deletes the projects

--- a/tools/alt-testing/create-projects.sh
+++ b/tools/alt-testing/create-projects.sh
@@ -1,0 +1,43 @@
+set -e
+
+# Expecting
+# TF_PROJECT_ID=
+# KRM_PROJECT_ID=
+# DM_PROJECT_ID=
+
+BILLING_ACCOUNT=[BILLING_ACCOUNT]
+FOLDER_ID=[FOLDER_ID]
+CLUSTER_ID=[CLUSTER_ID]
+ZONE=[ZONE]
+
+# Create DM project
+gcloud projects create $DM_PROJECT_ID --name="$DM_PROJECT_ID" --folder=$FOLDER_ID
+gcloud alpha billing projects link $DM_PROJECT_ID --billing-account $BILLING_ACCOUNT
+gcloud config set project $DM_PROJECT_ID
+
+# Create TF project
+gcloud projects create $TF_PROJECT_ID --name="$TF_PROJECT_ID" --folder=$FOLDER_ID
+gcloud alpha billing projects link $TF_PROJECT_ID --billing-account $BILLING_ACCOUNT
+gcloud config set project $TF_PROJECT_ID
+
+
+# Create KCC project and configure KCC cluster
+gcloud projects create $KRM_PROJECT_ID --name="$KRM_PROJECT_ID" --folder="$FOLDER_ID"
+gcloud alpha billing projects link $KRM_PROJECT_ID --billing-account $BILLING_ACCOUNT
+gcloud config set project $KRM_PROJECT_ID
+gcloud services enable cloudresourcemanager.googleapis.com --project ${KRM_PROJECT_ID}
+gcloud services enable container.googleapis.com --project ${KRM_PROJECT_ID}
+gcloud container clusters create ${CLUSTER_ID} --workload-pool=${KRM_PROJECT_ID}.svc.id.goog --enable-ip-alias --zone $ZONE
+gcloud container clusters get-credentials $CLUSTER_ID --zone=$ZONE
+gcloud iam service-accounts create cnrm-system --project ${KRM_PROJECT_ID}
+gcloud projects add-iam-policy-binding ${KRM_PROJECT_ID} --member "serviceAccount:cnrm-system@${KRM_PROJECT_ID}.iam.gserviceaccount.com" --role roles/owner
+gcloud iam service-accounts add-iam-policy-binding \
+    cnrm-system@${KRM_PROJECT_ID}.iam.gserviceaccount.com \
+    --member="serviceAccount:${KRM_PROJECT_ID}.svc.id.goog[cnrm-system/cnrm-controller-manager]" \
+    --role="roles/iam.workloadIdentityUser"
+gsutil cp gs://cnrm/latest/release-bundle.tar.gz release-bundle.tar.gz
+rm -rf release-bundle
+tar zxvf release-bundle.tar.gz
+sed -i.bak 's/${PROJECT_ID?}/'"$KRM_PROJECT_ID"'/' install-bundle-workload-identity/0-cnrm-system.yaml
+kubectl apply -f install-bundle-workload-identity/
+kubectl annotate namespace default "cnrm.cloud.google.com/project-id=${KRM_PROJECT_ID}" --overwrite

--- a/tools/alt-testing/create-projects.sh
+++ b/tools/alt-testing/create-projects.sh
@@ -1,10 +1,11 @@
 set -e
-
-# Expecting
+# This script can sourced into test_alternatives script
+# The following variables are expected to be defined in the parrent script
 # TF_PROJECT_ID=
 # KRM_PROJECT_ID=
 # DM_PROJECT_ID=
 
+# The following variables are local to this script and should be specified
 BILLING_ACCOUNT=[BILLING_ACCOUNT]
 FOLDER_ID=[FOLDER_ID]
 CLUSTER_ID=[CLUSTER_ID]

--- a/tools/alt-testing/delete-projects.sh
+++ b/tools/alt-testing/delete-projects.sh
@@ -1,0 +1,3 @@
+gcloud projects delete -q ${DM_PROJECT_ID}
+gcloud projects delete -q ${TF_PROJECT_ID}
+gcloud projects delete -q ${KRM_PROJECT_ID}


### PR DESCRIPTION
This is the first PR to add KRM and TF alternatives for BigQuery snippets. It can be used for subsequent PRs as example.

1. See go/dm-snippets-alternatives for objective and background
2. Adding readme to show how to launch each of the tools
3. Adding tf and krm directories with configs
4. Adding test_alternatives.sh intended to run manually
5. Adding create_projects and delete_projects scripts that can be used to simplify testing