### PR TITLE
Add example of specifying mostDisruptiveAllowedAction for instance

### DIFF
--- a/google/resource-snippets/compute-v1/instance.jinja
+++ b/google/resource-snippets/compute-v1/instance.jinja
@@ -28,3 +28,4 @@ resources:
     labels:
       somelabel: {{ properties["somelabel"] or "macano" }}
       fixedlabel: chanapulana
+    mostDisruptiveAllowedAction: RESTART


### PR DESCRIPTION
Deployment Manager now supports the ability to specify the `mostDisruptiveAllowedAction` when updating a Compute instance. The full set of valid values are detailed in the Compute Engine documentation for the update API [here](https://cloud.google.com/compute/docs/reference/rest/v1/instances/update).