### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For an overview of Deployment Manager, see https://cloud.google.com/deployment-m
 
 ## Try the samples
 
-Clone this repostory into [Cloud Shell](https://cloud.google.com/shell/), edit the samples, and deploy them from within Cloud Shell, without installing anything.
+Clone this repository into [Cloud Shell](https://cloud.google.com/shell/), edit the samples, and deploy them from within Cloud Shell, without installing anything.
 
 [![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fdeploymentmanager-samples&page=editor)
 


### PR DESCRIPTION
Fix a minor typo in README.md (`repostory` -> `repository`). My first PR, woohoo!
