### PR TITLE
Add TF config/testing script for cloudkms

### DIFF
--- a/google/resource-snippets/cloudkms-v1/README.md
+++ b/google/resource-snippets/cloudkms-v1/README.md
@@ -6,6 +6,7 @@ Setup:
 
 * Install [gcloud](https://cloud.google.com/sdk/docs/install)
 * Create GCP project
+* Setup [Credential](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started#adding-credentials)
 
 ```bash
 DM_PROJECT_ID=[DM_PROJECT_ID]
@@ -21,6 +22,7 @@ Setup:
 * Install [gcloud](https://cloud.google.com/sdk/docs/install)
 * Install [terraform](https://www.terraform.io/downloads.html)
 * Create GCP project
+* Setup [Credential](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started#adding-credentials)
 
 ```bash
 TF_PROJECT_ID=[TF_PROJECT_ID]

--- a/google/resource-snippets/cloudkms-v1/README.md
+++ b/google/resource-snippets/cloudkms-v1/README.md
@@ -1,0 +1,38 @@
+# Cloudkms Snippets
+
+## DM
+
+Setup:
+
+* Install [gcloud](https://cloud.google.com/sdk/docs/install)
+* Create GCP project
+
+```bash
+DM_PROJECT_ID=[DM_PROJECT_ID]
+gcloud config set project $DM_PROJECT_ID
+gcloud services enable deploymentmanager.googleapis.com
+gcloud deployment-manager deployments create d1 --config kms.yaml
+```
+
+## Terraform
+
+Setup:
+
+* Install [gcloud](https://cloud.google.com/sdk/docs/install)
+* Install [terraform](https://www.terraform.io/downloads.html)
+* Create GCP project
+
+```bash
+TF_PROJECT_ID=[TF_PROJECT_ID]
+gcloud config set project $TF_PROJECT_ID
+cd alternatives/tf
+terraform init
+terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+```
+
+## Testing
+
+```bash
+sh test_alternatives.sh
+```

--- a/google/resource-snippets/cloudkms-v1/alternatives/tf/cloudkms.tf
+++ b/google/resource-snippets/cloudkms-v1/alternatives/tf/cloudkms.tf
@@ -1,0 +1,45 @@
+variable "project_id" {}
+variable "deployment" {}
+
+provider "google" {
+  project = var.project_id
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}
+
+locals{
+    user = "user:zyanshu@google.com"
+}
+
+resource "google_kms_key_ring" "default" {
+  name     = "test--keyring"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "default" {
+  name            = format("%s-cryptoKey", var.deployment)
+  key_ring        = google_kms_key_ring.default.id
+  purpose         = "ENCRYPT_DECRYPT"
+  labels = {
+    foo = var.deployment
+  }
+}
+
+data "google_iam_policy" "admin" {
+  binding {
+    role = "roles/cloudkms.admin"
+
+    members = [
+      local.user,
+    ]
+  }
+}
+
+resource "google_kms_crypto_key_iam_policy" "crypto_key" {
+  crypto_key_id = google_kms_crypto_key.default.id
+  policy_data = data.google_iam_policy.admin.policy_data
+}
+
+data "google_kms_crypto_key_version" "crypto-key-version" {
+  crypto_key =  google_kms_crypto_key.default.self_link
+}

--- a/google/resource-snippets/cloudkms-v1/alternatives/tf/cloudkms.tf
+++ b/google/resource-snippets/cloudkms-v1/alternatives/tf/cloudkms.tf
@@ -1,5 +1,6 @@
 variable "project_id" {}
 variable "deployment" {}
+variable "user" {}
 
 provider "google" {
   project = var.project_id
@@ -7,19 +8,15 @@ provider "google" {
   zone    = "us-central1-c"
 }
 
-locals{
-    user = "user:zyanshu@google.com"
-}
-
 resource "google_kms_key_ring" "default" {
-  name     = "test--keyring"
+  name     = "test-keyring"
   location = "us-central1"
 }
 
 resource "google_kms_crypto_key" "default" {
-  name            = format("%s-cryptoKey", var.deployment)
-  key_ring        = google_kms_key_ring.default.id
-  purpose         = "ENCRYPT_DECRYPT"
+  name     = format("%s-cryptoKey", var.deployment)
+  key_ring = google_kms_key_ring.default.id
+  purpose  = "ENCRYPT_DECRYPT"
   labels = {
     foo = var.deployment
   }
@@ -30,16 +27,16 @@ data "google_iam_policy" "admin" {
     role = "roles/cloudkms.admin"
 
     members = [
-      local.user,
+      var.user,
     ]
   }
 }
 
 resource "google_kms_crypto_key_iam_policy" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.default.id
-  policy_data = data.google_iam_policy.admin.policy_data
+  policy_data   = data.google_iam_policy.admin.policy_data
 }
 
 data "google_kms_crypto_key_version" "crypto-key-version" {
-  crypto_key =  google_kms_crypto_key.default.self_link
+  crypto_key = google_kms_crypto_key.default.self_link
 }

--- a/google/resource-snippets/cloudkms-v1/kms.jinja
+++ b/google/resource-snippets/cloudkms-v1/kms.jinja
@@ -17,7 +17,7 @@ resources:
   type: gcp-types/cloudkms-v1:projects.locations.keyRings
   properties:
     parent: projects/{{ env["project"] }}/locations/{{ properties["region"] }}
-    keyRingId: test-{{ properties["time"] }}-keyRing
+    keyRingId: test-keyRing
 - name: cryptoKey
   type: gcp-types/cloudkms-v1:projects.locations.keyRings.cryptoKeys
   properties:

--- a/google/resource-snippets/cloudkms-v1/kms.yaml
+++ b/google/resource-snippets/cloudkms-v1/kms.yaml
@@ -21,5 +21,5 @@ resources:
 - name: kms
   type: kms.jinja
   properties:
-    region: us-central1
-    user: zyanshu@google.com
+    region: REGION_TO_RUN
+    user: ananke.iam@gmail.com

--- a/google/resource-snippets/cloudkms-v1/kms.yaml
+++ b/google/resource-snippets/cloudkms-v1/kms.yaml
@@ -21,5 +21,5 @@ resources:
 - name: kms
   type: kms.jinja
   properties:
-    region: REGION_TO_RUN
-    user: ananke.iam@gmail.com
+    region: us-central1
+    user: zyanshu@google.com

--- a/google/resource-snippets/cloudkms-v1/test_alternatives.sh
+++ b/google/resource-snippets/cloudkms-v1/test_alternatives.sh
@@ -1,33 +1,31 @@
 set -e
 
 # assumes that the following projects are created and kubectl context is set to a cluster in KRM_PROJECT
-TF_PROJECT_ID=zyanshu-dm-convert 
-DM_PROJECT_ID=zyanshu-dm-convert-dm
-
-# source ../../../../tools/alt-testing/create-projects.sh
+TF_PROJECT_ID=[TF_PROJECT_ID]
+DM_PROJECT_ID=[DM_PROJECT_ID]
 
 gcloud auth application-default login
 
 # Create DM resources
 gcloud config set project $DM_PROJECT_ID
-gcloud services enable deploymentmanager.googleapis.com
+gcloud services enable deploymentmanager.googleapis.com --project $DM_PROJECT_ID
+gcloud services enable cloudkms.googleapis.com --project $DM_PROJECT_ID
 gcloud deployment-manager deployments create d1 --config kms.yaml
 
 # Create Terraform resources
 pushd alternatives/tf
 gcloud config set project $TF_PROJECT_ID
-terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+gcloud services enable cloudkms.googleapis.com --project $TF_PROJECT_ID
+terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}" -var="user=<user_name>"
 terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
 popd
 
 # Export DM and TF resources for comparison
-gcloud kms keys list --keyring test--keyRing --location us-central1 --project $DM_PROJECT_ID | grep d1 | sed "s/${DM_PROJECT_ID}/PROJECT/" \
+gcloud kms keys list --keyring test-keyRing --location us-central1 --project $DM_PROJECT_ID | grep d1 | sed "s/${DM_PROJECT_ID}/PROJECT/" \
 > /tmp/${DM_PROJECT_ID}.yaml
 
-gcloud kms keys list --keyring test--keyRing --location us-central1 --project $TF_PROJECT_ID | grep d1 | sed "s/${TF_PROJECT_ID}/PROJECT/" \
+gcloud kms keys list --keyring test-keyRing --location us-central1 --project $TF_PROJECT_ID | grep d1 | sed "s/${TF_PROJECT_ID}/PROJECT/" \
 > /tmp/${TF_PROJECT_ID}.yaml
-
-# source ../../../../tools/alt-testing/delete-projects.sh
 
 diff /tmp/${TF_PROJECT_ID}.yaml /tmp/${DM_PROJECT_ID}.yaml
 

--- a/google/resource-snippets/cloudkms-v1/test_alternatives.sh
+++ b/google/resource-snippets/cloudkms-v1/test_alternatives.sh
@@ -1,0 +1,41 @@
+set -e
+
+# assumes that the following projects are created and kubectl context is set to a cluster in KRM_PROJECT
+TF_PROJECT_ID=zyanshu-dm-convert 
+DM_PROJECT_ID=zyanshu-dm-convert-dm
+
+# source ../../../../tools/alt-testing/create-projects.sh
+
+gcloud auth application-default login
+
+# Create DM resources
+gcloud config set project $DM_PROJECT_ID
+gcloud services enable deploymentmanager.googleapis.com
+gcloud deployment-manager deployments create d1 --config kms.yaml
+
+# Create Terraform resources
+pushd alternatives/tf
+gcloud config set project $TF_PROJECT_ID
+terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+popd
+
+# Export DM and TF resources for comparison
+gcloud kms keys list --keyring test--keyRing --location us-central1 --project $DM_PROJECT_ID | grep d1 | sed "s/${DM_PROJECT_ID}/PROJECT/" \
+> /tmp/${DM_PROJECT_ID}.yaml
+
+gcloud kms keys list --keyring test--keyRing --location us-central1 --project $TF_PROJECT_ID | grep d1 | sed "s/${TF_PROJECT_ID}/PROJECT/" \
+> /tmp/${TF_PROJECT_ID}.yaml
+
+# source ../../../../tools/alt-testing/delete-projects.sh
+
+diff /tmp/${TF_PROJECT_ID}.yaml /tmp/${DM_PROJECT_ID}.yaml
+
+if [[ $(diff /tmp/${TF_PROJECT_ID}.yaml /tmp/${DM_PROJECT_ID}.yaml) ]]; then
+    echo "TF and DM outputs are NOT identical"
+    exit 1
+else
+    echo "TF and DM outputs are identical"
+fi
+
+exit 0


### PR DESCRIPTION
This is the PR to add TF alternatives for CloudKms snippets.

See go/dm-snippets-alternatives for objective and background
Adding readme to show how to launch each of the tools
Adding tf directories with configs
Adding test_alternatives.sh intended to run manually
