### PR TITLE
Improve test_alternatives.sh script 

### DIFF
--- a/google/resource-snippets/pubsub-v1/README.md
+++ b/google/resource-snippets/pubsub-v1/README.md
@@ -12,7 +12,7 @@ DM_PROJECT_ID=[DM_PROJECT_ID]
 gcloud config set project $DM_PROJECT_ID
 gcloud services enable pubsub.googleapis.com
 gcloud services enable deploymentmanager.googleapis.com
-gcloud deployment-manager deployments create d1 --config pubsub.yaml
+gcloud deployment-manager deployments create deployment --config pubsub.yaml
 ```
 
 ## Terraform
@@ -30,7 +30,7 @@ gcloud config set project $TF_PROJECT_ID
 gcloud services enable pubsub.googleapis.com
 cd alternatives/tf
 terraform init
-terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
+terraform apply -auto-approve -var="deployment=deployment" -var="project_id=${TF_PROJECT_ID}"
 ```
 ## KRM
 

--- a/google/resource-snippets/pubsub-v1/alternatives/krm/pubsub.yaml
+++ b/google/resource-snippets/pubsub-v1/alternatives/krm/pubsub.yaml
@@ -8,10 +8,10 @@ kind: PubSubSubscription
 metadata:
   name: ${PUBSUB?}-subscription # {"$ref":"#/definitions/io.k8s.cli.substitutions.subscription-subs"}
   labels:
-    goog-dm: d1
+    goog-dm: deployment
 spec:
   topicRef:
-    name: {$PUBSUB?}-topic # {"$ref":"#/definitions/io.k8s.cli.substitutions.topic-subs"}
+    name: ${PUBSUB?}-topic # {"$ref":"#/definitions/io.k8s.cli.substitutions.topic-subs"}
   ackDeadlineSeconds: 60
   messageRetentionDuration: "1200s"
   retainAckedMessages: true

--- a/google/resource-snippets/pubsub-v1/test_alternatives.sh
+++ b/google/resource-snippets/pubsub-v1/test_alternatives.sh
@@ -1,64 +1,79 @@
 set -e
 
-TF_PROJECT_ID={TF_PROJECT_ID}
-DM_PROJECT_ID={DM_PROJECT_ID}
-KRM_PROJECT_ID={KRM_PROJECT_ID}
+GREEN_COLOR='\033[0;32m'
+RED_COLOR='\033[0;31m'
+RESET_COLOR='\033[0m'
 
-# Create DM resources
-gcloud config set project $DM_PROJECT_ID
+provision_using_dm() {
+  gcloud deployment-manager deployments create deployment --config pubsub.yaml
+  gcloud pubsub subscriptions list --filter="labels.goog-dm:deployment" --project "${PROJECT_ID}" > /tmp/dm.yaml
+  gcloud deployment-manager deployments delete deployment -q
+}
 
-#Authentication
-gcloud auth application-default login
-export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.json
+provision_using_tf() {
+  if [[ -z "${GOOGLE_CREDENTIALS}" ]]; then
+    # For pub/sub, the ADC will have sufficient permissions
+    echo "Fetching Application Default Credentials for Terraform"
+    gcloud auth application-default login
+    export GOOGLE_CREDENTIALS=~/.config/gcloud/application_default_credentials.json
+  fi
+
+  cp -R alternatives/tf/ /tmp/tf_"${PROJECT_ID}"
+  pushd /tmp/tf_"${PROJECT_ID}"
+  terraform init
+  terraform plan -var="deployment=deployment" -var="project_id=${PROJECT_ID}"
+  terraform apply -auto-approve -var="deployment=deployment" -var="project_id=${PROJECT_ID}"
+  gcloud pubsub subscriptions list --filter="labels.goog-dm:deployment" --project "${PROJECT_ID}" > /tmp/tf.yaml
+  terraform destroy -auto-approve -var="deployment=deployment" -var="project_id=${PROJECT_ID}"
+  popd
+  rm -rf /tmp/tf_${PROJECT_ID}
+}
+
+provision_using_krm() {
+  cp -R alternatives/krm/ /tmp/krm_${PROJECT_ID}
+  pushd /tmp/krm_${PROJECT_ID}
+  kpt cfg set . PUBSUB my-pubsub
+  kubectl apply -f pubsub.yaml
+  kubectl wait --for=condition=Ready --timeout=60s PubSubSubscription --all
+  gcloud pubsub subscriptions list --filter="labels.goog-dm:deployment" --project "${PROJECT_ID}" | sed "s/creationTime: .*/creationTime: TIME/" | sed "/cnrm-lease-.*/d" | sed "/managed-by-cnrm.*/d"  > /tmp/krm.yaml
+  kubectl delete -f pubsub.yaml
+  popd
+  rm -rf krm_${PROJECT_ID}
+}
+
+gcloud config set project "${PROJECT_ID}"
+
+if [[ -n $( gcloud auth list --filter=status:ACTIVE --format="value(account)" ) ]]; then
+  account_name=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
+  echo "Reusing $account_name user credentials"
+else
+  gcloud auth login
+fi
 
 gcloud services enable deploymentmanager.googleapis.com
-gcloud deployment-manager deployments create d1 --config pubsub.yaml
+gcloud services enable pubsub.googleapis.com
 
-# Create Terraform resources
-pushd alternatives/tf
-gcloud config set project $TF_PROJECT_ID
+provision_using_dm
+provision_using_tf
+provision_using_krm
 
-#Authentication
-gcloud auth application-default login
-export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.json
-
-# Initialize Terraform and apply resources
-terraform init
-terraform plan -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
-terraform apply -auto-approve -var="deployment=d1" -var="project_id=${TF_PROJECT_ID}"
-popd
-
-# KCC Configuration
-gcloud config set project $KRM_PROJECT_ID
-cp -R alternatives/krm /tmp/krm_${KRM_PROJECT_ID}
-pushd /tmp/krm_${KRM_PROJECT_ID}
-kpt cfg set . PUBSUB my-pubsub
-kubectl apply -f pubsub.yaml
-kubectl  wait --for=condition=Ready PubSubSubscription --all
-popd
-rm -rf krm_${KRM_PROJECT_ID}
-
-
-# Export DM and TF resources for comparison
-gcloud pubsub subscriptions list --filter="labels.goog-dm:d1" --project $DM_PROJECT_ID | sed "s/${DM_PROJECT_ID}/PROJECT/" > /tmp/dm.yaml
-
-gcloud pubsub subscriptions list --filter="labels.goog-dm:d1" --project $TF_PROJECT_ID | sed "s/${TF_PROJECT_ID}/PROJECT/"  > /tmp/tf.yaml
-
-gcloud pubsub subscriptions list --filter="labels.goog-dm:d1" --project $KRM_PROJECT_ID | sed "s/${KRM_PROJECT_ID}/PROJECT/" | sed "s/creationTime: .*/creationTime: TIME/" | sed "/cnrm-lease-.*/d" | sed "/managed-by-cnrm.*/d"  > /tmp/krm.yaml
-
-
-if [[ $(diff /tmp/dm.yaml /tmp/tf.yaml) ]]; then
-    echo "TF and DM outputs are NOT identical"
+if [[ -n $(diff /tmp/dm.yaml /tmp/tf.yaml) ]]; then
+    echo "${RED_COLOR}TF and DM outputs are NOT identical${RESET_COLOR}"
+    echo "diff /tmp/dm.yaml /tmp/tf.yaml"
+    diff /tmp/dm.yaml /tmp/tf.yaml
     exit 1
 else
-    echo "TF and DM outputs are identical"
+    echo "${GREEN_COLOR}TF and DM outputs are identical${RESET_COLOR}"
 fi
 
-if [[ $(diff /tmp/dm.yaml /tmp/krm.yaml) ]]; then
-    echo "KRM and DM outputs are NOT identical"
+if [[ -n $(diff /tmp/dm.yaml /tmp/krm.yaml) ]]; then
+    echo "${RED_COLOR}KRM and DM outputs are NOT identical${RESET_COLOR}"
+    echo "diff /tmp/dm.yaml /tmp/krm.yaml"
+    diff /tmp/dm.yaml /tmp/krm.yaml
     exit 1
 else
-    echo "KRM and DM outputs are identical"
+    echo "${GREEN_COLOR}KRM and DM outputs are identical${RESET_COLOR}"
 fi
 
+echo "${GREEN_COLOR}Test Success${RESET_COLOR}"
 exit 0

--- a/google/resource-snippets/pubsub-v1/test_alternatives.sh
+++ b/google/resource-snippets/pubsub-v1/test_alternatives.sh
@@ -38,7 +38,7 @@ provision_using_krm() {
   gcloud pubsub subscriptions list --filter="labels.goog-dm:deployment" --project "${PROJECT_ID}" | sed "s/creationTime: .*/creationTime: TIME/" | sed "/cnrm-lease-.*/d" | sed "/managed-by-cnrm.*/d"  > /tmp/krm.yaml
   kubectl delete -f pubsub.yaml
   popd
-  rm -rf krm_${PROJECT_ID}
+  rm -rf /tmp/krm_${PROJECT_ID}
 }
 
 gcloud config set project "${PROJECT_ID}"


### PR DESCRIPTION
Improvements:

- Create functions for each DM/TF/KRM provisioning resources
- Don't require the user to login if we can detect that valid creds exist
- Colorize the success and failure messages
- Use only one project instead of requiring 3 different projects
- Clean up the resources after provisioning resources
- Fix a few bugs here and there, like
  - `cp -R alternatives/krm` should be `cp -R alternatives/krm/`, and same for Terraform
  - Add 60s timeout for waiting for `PubSubSubscription`
- Change deployment name from `d1` to `deployment` to be slightly more descriptive

If this PR looks good, I'll make similar changes to the other existing `test_alternatives.sh` script. This should make future `test_alternatives.sh` script better.