### PR TITLE
Update GKE templates from swaggerapi to openapi

### DIFF
--- a/examples/v2/gke/jinja/cluster.jinja
+++ b/examples/v2/gke/jinja/cluster.jinja
@@ -15,11 +15,10 @@ limitations under the License.
 {% set NAME_PREFIX = env['deployment'] + '-' + env['name'] %}
 {% set CLUSTER_NAME = NAME_PREFIX %}
 {% set TYPE_NAME = NAME_PREFIX + '-type' %}
-{% set K8S_ENDPOINTS = {'': 'api/v1', '-apps': 'apis/apps/v1beta1', '-v1beta1-extensions': 'apis/extensions/v1beta1'} %}
 
 resources:
 - name: {{ CLUSTER_NAME }}
-  type: container.v1.cluster
+  type: gcp-types/container-v1:projects.zones.clusters
   properties:
     zone: {{ properties['zone'] }}
     cluster:
@@ -31,8 +30,7 @@ resources:
         - https://www.googleapis.com/auth/devstorage.read_only
         - https://www.googleapis.com/auth/logging.write
         - https://www.googleapis.com/auth/monitoring
-{% for typeSuffix, endpoint in K8S_ENDPOINTS.items() %}
-- name: {{ TYPE_NAME }}{{ typeSuffix }}
+- name: {{ TYPE_NAME }}
   type: deploymentmanager.v2beta.typeProvider
   properties:
     options:
@@ -49,7 +47,7 @@ resources:
       inputMappings:
       - fieldName: name
         location: PATH
-        methodMatch: ^(GET|DELETE|PUT)$
+        methodMatch: ^(GET|DELETE|PUT|POST|PATCH)$
         value: $.ifNull($.resource.properties.metadata.name, $.resource.name)
       - fieldName: metadata.name
         location: BODY
@@ -59,12 +57,18 @@ resources:
         location: HEADER
         value: >
           $.concat("Bearer ", $.googleOauth2AccessToken())
-    descriptorUrl: https://$(ref.{{ CLUSTER_NAME }}.endpoint)/swaggerapi/{{ endpoint }}
-{% endfor %}
+      - fieldName: metadata.resourceVersion
+        location: BODY
+        methodMatch: ^(PUT|PATCH)$
+        value: $.resource.self.metadata.resourceVersion
+      - fieldName: id
+        location: PATH
+        methodMatch: ^(GET|DELETE|PUT|POST|PATCH)$
+        value: $.resource.properties.id
+      - fieldName: namespace
+        location: PATH
+        methodMatch: ^(GET|DELETE|PUT|POST|PATCH)$
+        value: $.resource.properties.namespace
+    descriptorUrl: https://$(ref.{{ CLUSTER_NAME }}.endpoint)/openapi/v2
 
-outputs:
-{% for typeSuffix, endpoint in K8S_ENDPOINTS.items() %}
-- name: clusterType{{ typeSuffix }}
-  value: {{ TYPE_NAME }}{{ typeSuffix }}
-{% endfor %}
 

--- a/examples/v2/gke/jinja/deployment.jinja
+++ b/examples/v2/gke/jinja/deployment.jinja
@@ -14,11 +14,8 @@ limitations under the License.
 
 {% set CLUSTER_TYPE = env['project'] + '/' + properties['clusterType'] %}
 
-{% set SERVICE_COLLECTION_PREFIX = '/api/v1/namespaces/{namespace}/' %}
-{% set SERVICE_COLLECTION = SERVICE_COLLECTION_PREFIX + 'services' %}
-
-{% set DEPLOYMENT_COLLECTION_PREFIX = '/apis/apps/v1beta1/namespaces/{namespace}/' %}
-{% set DEPLOYMENT_COLLECTION = DEPLOYMENT_COLLECTION_PREFIX + 'deployments' %}
+{% set SERVICE_COLLECTION = '/api/v1/namespaces/{namespace}/services/{name}' %}
+{% set DEPLOYMENT_COLLECTION = '/apis/apps/v1/namespaces/{namespace}/deployments/{name}' %}
 
 {% set NAME_PREFIX = env['deployment'] + '-' + env['name'] %}
 
@@ -45,15 +42,18 @@ resources:
         app: {{ NAME_PREFIX }}
 
 - name: {{ NAME_PREFIX }}-deployment
-  type: {{ CLUSTER_TYPE }}-apps:{{ DEPLOYMENT_COLLECTION }}
+  type: {{ CLUSTER_TYPE }}:{{ DEPLOYMENT_COLLECTION }}
   properties:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     namespace: default
     metadata:
       name: {{ NAME_PREFIX }}-deployment
     spec:
       replicas: 1
+      selector:
+        matchLabels:
+          app: {{ NAME_PREFIX }}
       template:
         metadata:
           labels:

--- a/examples/v2/gke/jinja/deployment.yaml
+++ b/examples/v2/gke/jinja/deployment.yaml
@@ -19,6 +19,6 @@ resources:
 - name: my-service
   type: deployment.jinja
   properties:
-    clusterType: m-my-cluster-type #<cluster-type>
+    clusterType: <cluster-type>
     image: nginx #gcr.io/deployment-manager-examples/nodejsservicestatic
     port: 80

--- a/examples/v2/gke/python/cluster.py
+++ b/examples/v2/gke/python/cluster.py
@@ -22,16 +22,11 @@ def GenerateConfig(context):
   name_prefix = context.env['deployment'] + '-' + context.env['name']
   cluster_name = name_prefix
   type_name = name_prefix + '-type'
-  k8s_endpoints = {
-      '': 'api/v1',
-      '-apps': 'apis/apps/v1beta1',
-      '-v1beta1-extensions': 'apis/extensions/v1beta1'
-  }
 
   resources = [
       {
           'name': cluster_name,
-          'type': 'container.v1.cluster',
+          'type': 'gcp-types/container-v1:projects.zones.clusters',
           'properties': {
               'zone': context.properties['zone'],
               'cluster': {
@@ -52,56 +47,64 @@ def GenerateConfig(context):
           }
       }
   ]
-  outputs = []
-  for type_suffix, endpoint in six.iteritems(k8s_endpoints):
-    resources.append({
-        'name': type_name + type_suffix,
-        'type': 'deploymentmanager.v2beta.typeProvider',
-        'properties': {
-            'options': {
-                'validationOptions': {
-                    # Kubernetes API accepts ints, in fields they annotate
-                    # with string. This validation will show as warning
-                    # rather than failure for Deployment Manager.
-                    # https://github.com/kubernetes/kubernetes/issues/2971
-                    'schemaValidation': 'IGNORE_WITH_WARNINGS'
-                },
-                # According to kubernetes spec, the path parameter 'name'
-                # should be the value inside the metadata field
-                # https://github.com/kubernetes/community/blob/master
-                # /contributors/devel/api-conventions.md
-                # This mapping specifies that
-                'inputMappings': [{
-                    'fieldName': 'name',
-                    'location': 'PATH',
-                    'methodMatch': '^(GET|DELETE|PUT)$',
-                    'value': '$.ifNull('
-                             '$.resource.properties.metadata.name, '
-                             '$.resource.name)'
-                }, {
-                    'fieldName': 'metadata.name',
-                    'location': 'BODY',
-                    'methodMatch': '^(PUT|POST)$',
-                    'value': '$.ifNull('
-                             '$.resource.properties.metadata.name, '
-                             '$.resource.name)'
-                }, {
-                    'fieldName': 'Authorization',
-                    'location': 'HEADER',
-                    'value': '$.concat("Bearer ",'
-                             '$.googleOauth2AccessToken())'
-                }]
-            },
-            'descriptorUrl':
-                ''.join([
-                    'https://$(ref.', cluster_name, '.endpoint)/swaggerapi/',
-                    endpoint
-                ])
-        }
-    })
-    outputs.append({
-        'name': 'clusterType' + type_suffix,
-        'value': type_name + type_suffix
-    })
+  resources.append({
+      'name': type_name,
+      'type': 'deploymentmanager.v2beta.typeProvider',
+      'properties': {
+          'options': {
+              'validationOptions': {
+                  # Kubernetes API accepts ints, in fields they annotate
+                  # with string. This validation will show as warning
+                  # rather than failure for Deployment Manager.
+                  # https://github.com/kubernetes/kubernetes/issues/2971
+                  'schemaValidation': 'IGNORE_WITH_WARNINGS'
+              },
+              # According to kubernetes spec, the path parameter 'name'
+              # should be the value inside the metadata field
+              # https://github.com/kubernetes/community/blob/master
+              # /contributors/devel/api-conventions.md
+              # This mapping specifies that
+              'inputMappings': [{
+                  'fieldName': 'name',
+                  'location': 'PATH',
+                  'methodMatch': '^(GET|DELETE|PUT|POST|PATCH)$',
+                  'value': '$.ifNull('
+                           '$.resource.properties.metadata.name, '
+                           '$.resource.name)'
+              }, {
+                  'fieldName': 'metadata.name',
+                  'location': 'BODY',
+                  'methodMatch': '^(PUT|POST)$',
+                  'value': '$.ifNull('
+                           '$.resource.properties.metadata.name, '
+                           '$.resource.name)'
+              }, {
+                  'fieldName': 'Authorization',
+                  'location': 'HEADER',
+                  'value': '$.concat("Bearer ",'
+                           '$.googleOauth2AccessToken())'
+              }, {
+                  'fieldName': 'metadata.resourceVersion',
+                  'location': 'BODY',
+                  'methodMatch': '^(PUT|PATCH)$',
+                  'value': '$.resource.self.metadata.resourceVersion'
+              }, {
+                  'fieldName': 'id',
+                  'location': 'PATH',
+                  'methodMatch': '^(GET|DELETE|PUT|POST|PATCH)$',
+                  'value': '$.resource.properties.id'
+              }, {
+                  'fieldName': 'namespace',
+                  'location': 'PATH',
+                  'methodMatch': '^(GET|DELETE|PUT|POST|PATCH)$',
+                  'value': '$.resource.properties.namespace'
+              }]
+          },
+          'descriptorUrl':
+              ''.join([
+                  'https://$(ref.', cluster_name, '.endpoint)/openapi/v2'
+              ])
+      }
+  })
 
-  return {'resources': resources, 'outputs': outputs}
+  return {'resources': resources}

--- a/examples/v2/gke/python/deployment.py
+++ b/examples/v2/gke/python/deployment.py
@@ -26,13 +26,12 @@ def GenerateConfig(context):
       'Service': ''.join([
           cluster_types_root,
           ':',
-          '/api/v1/namespaces/{namespace}/services'
+          '/api/v1/namespaces/{namespace}/services/{name}'
           ]),
       'Deployment': ''.join([
           cluster_types_root,
-          '-apps',
           ':',
-          '/apis/apps/v1beta1/namespaces/{namespace}/deployments'
+          '/apis/apps/v1/namespaces/{namespace}/deployments/{name}'
           ])
   }
 
@@ -68,7 +67,7 @@ def GenerateConfig(context):
       'name': name_prefix + '-deployment',
       'type': cluster_types['Deployment'],
       'properties': {
-          'apiVersion': 'apps/v1beta1',
+          'apiVersion': 'apps/v1',
           'kind': 'Deployment',
           'namespace': 'default',
           'metadata': {
@@ -76,6 +75,11 @@ def GenerateConfig(context):
           },
           'spec': {
               'replicas': 1,
+              'selector': {
+                  'matchLabels': {
+                      'app': name_prefix
+                  }
+              },
               'template': {
                   'metadata': {
                       'labels': {


### PR DESCRIPTION
These examples have been out of date for a bit since swaggerapi became deprecated within GKE. This updates them to openapi and also moves the DM type to the newer, more update type definition

Fixes #618
Fixes #619