### PR TITLE
Reduce the overhead of the dataproc example

### DIFF
--- a/google/resource-snippets/dataproc-v1/dataproc.jinja
+++ b/google/resource-snippets/dataproc-v1/dataproc.jinja
@@ -32,7 +32,10 @@ resources:
       masterConfig:
         numInstances: 1
         machineTypeUri: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/machineTypes/n1-standard-2
+        diskConfig:
+          bootDiskSizeGb: 50        
       workerConfig:
         numInstances: {{ properties["initialWorkerSize"] }}
         machineTypeUri: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/machineTypes/n1-standard-2
-
+        diskConfig:
+          bootDiskSizeGb: 50

--- a/google/resource-snippets/dataproc-v1/dataproc.yaml
+++ b/google/resource-snippets/dataproc-v1/dataproc.yaml
@@ -21,6 +21,6 @@ resources:
   properties:
     # Don't change "initialWorkerSize" after dataproc cluster get created 
     # since dataproc doesn't support UPDATE request on exsiting cluster.
-    initialWorkerSize: 3
+    initialWorkerSize: 2
     region: REGION_TO_RUN
     zone: ZONE_TO_RUN


### PR DESCRIPTION
As it currently exists, the Dataproc example uses 2TB of disk space between the main and worker configs. This reduces  that to 150GB by reducing the disk config and the worker size.