### PR TITLE
Update forwarding rule examples to internal instead of external

### DIFF
--- a/google/resource-snippets/compute-v1/forwarding_rule.jinja
+++ b/google/resource-snippets/compute-v1/forwarding_rule.jinja
@@ -18,10 +18,13 @@ resources:
   properties:
     region: {{ properties["region"] }}
     IPProtocol: TCP
-    portRange: 80
-    target: $(ref.target-pool-{{ env["deployment"] }}.selfLink)
-- type: gcp-types/compute-v1:targetPools
-  name: target-pool-{{ env["deployment"] }}
+    allPorts: true
+    target: $(ref.target-instance-{{ env["deployment"] }}.selfLink)
+    loadBalancingScheme: INTERNAL
+- type: gcp-types/compute-v1:targetInstances
+  name: target-instance-{{ env["deployment"] }}
   properties:
-    description: integration test target pool
-    region: {{ properties["region"] }}
+    natPolicy: NO_NAT
+    instance: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/instances/instance-404
+    description: integration test target instance
+    zone: {{ properties["zone"] }}

--- a/google/resource-snippets/compute-v1/forwarding_rule.yaml
+++ b/google/resource-snippets/compute-v1/forwarding_rule.yaml
@@ -20,3 +20,4 @@ resources:
   type: forwarding_rule.jinja
   properties:
     region: REGION_TO_RUN
+    zone: ZONE_TO_RUN

--- a/google/resource-snippets/compute-v1/global_forwarding_rule.jinja
+++ b/google/resource-snippets/compute-v1/global_forwarding_rule.jinja
@@ -25,20 +25,18 @@ resources:
   properties:
     region: {{ properties["region"] }}
     IPProtocol: TCP
+    IPAddress: 127.0.0.1
     portRange: 80
     target: $(ref.{{ TARGET }}.selfLink)
+    loadBalancingScheme: INTERNAL_SELF_MANAGED
 
-- type: gcp-types/compute-v1:httpHealthChecks
+- type: gcp-types/compute-v1:healthChecks
   name: {{ HEALTHCHECK }}
   properties:
-    host: localhost
-    port: 8080
-    requestPath: /path/to/my/service
-    timeoutSec: 3
-    description: integration test http health check
-    checkIntervalSec: 3
-    unhealthyThreshold: 5
-    healthyThreshold: 2
+    type: TCP
+    tcpHealthCheck:
+      portName: test-port
+      port: 8080
 
 - type: gcp-types/compute-v1:backendServices
   name: {{ BS1 }}
@@ -50,6 +48,7 @@ resources:
     portName: http
     protocol: HTTP
     timeoutSec: 30
+    loadBalancingScheme: INTERNAL_SELF_MANAGED
 
 - type: gcp-types/compute-v1:backendServices
   name: {{ BS2 }}
@@ -61,6 +60,7 @@ resources:
     portName: http
     protocol: HTTP
     timeoutSec: 30
+    loadBalancingScheme: INTERNAL_SELF_MANAGED
 
 - type: gcp-types/compute-v1:urlMaps
   name: {{ URLMAP }}


### PR DESCRIPTION
In order to continue using these in tests we need to update them to be internal instead of external. The changes here are meant to be minimal while still converting everything over.