### PR TITLE
Add GAE app to uptime check config manifest

### DIFF
--- a/google/resource-snippets/monitoring-v3/uptime_check_configs.jinja
+++ b/google/resource-snippets/monitoring-v3/uptime_check_configs.jinja
@@ -1,0 +1,34 @@
+resources:
+- name: uptime-check-{{ env["deployment"] }}
+  type: gcp-types/monitoring-v3:projects.uptimeCheckConfigs
+  properties:
+    displayName: My uptime check
+    httpCheck:
+      path: /
+      port: 80
+    monitoredResource:
+      labels:
+        module_id: default
+        project_id: {{ env["project"] }}
+        version_id: $(ref.app-{{ env["deployment"] }}.id)
+      type: gae_app
+    period: 300s
+    timeout: 10s
+- name: app-{{ env["deployment"] }}
+  type: gcp-types/appengine-v1:apps.services.versions
+  properties:
+    servicesId: default
+    appsId: {{ env["project"] }}
+    deployment:
+      files:
+        main.py:
+          sourceUrl: https://storage.googleapis.com/admin-api-public-samples/hello_world/main.py
+    handlers:
+      - script:
+          scriptPath: main.app
+        securityLevel: SECURE_OPTIONAL
+        urlRegex: /
+    runtime: python27
+    threadsafe: true
+
+

--- a/google/resource-snippets/monitoring-v3/uptime_check_configs.yaml
+++ b/google/resource-snippets/monitoring-v3/uptime_check_configs.yaml
@@ -1,15 +1,6 @@
+imports:
+- path: uptime_check_configs.jinja
+
 resources:
 - name: uptime_check_config
-  type: gcp-types/monitoring-v3:projects.uptimeCheckConfigs
-  properties:
-    displayName: My uptime check
-    httpCheck:
-      path: /
-      port: 80
-    monitoredResource:
-      labels:
-        module_id: default
-      type: gae_app
-    period: 300s
-    timeout: 10s
-
+  type: uptime_check_configs.jinja


### PR DESCRIPTION
This stopped working a while ago because the Monitoring service started requiring that the GAE app being monitored be up and running in order to successfully create the uptime check. This adds a lightweight GAE app to the config to get things working.