### PR TITLE
Add support for setting uptimeCheckConfig from YAML 

### DIFF
--- a/google/resource-snippets/monitoring-v3/uptime_check_configs.jinja
+++ b/google/resource-snippets/monitoring-v3/uptime_check_configs.jinja
@@ -13,7 +13,7 @@ resources:
         version_id: $(ref.app-{{ env["deployment"] }}.id)
       type: gae_app
     period: 300s
-    timeout: 10s
+    timeout: {{ properties["timeout"] }}
 - name: app-{{ env["deployment"] }}
   type: gcp-types/appengine-v1:apps.services.versions
   properties:

--- a/google/resource-snippets/monitoring-v3/uptime_check_configs.yaml
+++ b/google/resource-snippets/monitoring-v3/uptime_check_configs.yaml
@@ -4,3 +4,5 @@ imports:
 resources:
 - name: uptime_check_config
   type: uptime_check_configs.jinja
+  properties:
+    timeout: 10s


### PR DESCRIPTION
When I converted the config to using a Jinja file I forgot to make the timeout configurable from the YAML file. This updates the Jinja file to read a property for the timeout, and adds that property to the base YAML to be overriden.