### PR TITLE
compute-v1-firewall TF alternative

### DIFF
--- a/examples/v2/sqladmin/jinja/sqladmin.jinja
+++ b/examples/v2/sqladmin/jinja/sqladmin.jinja
@@ -22,7 +22,7 @@ resources:
     name: {{ database_name }}
     instance: $(ref.{{ instance_name }}.name)
     charset: utf8
-{% set dependency = 'database_name' %}
+{% set dependency = database_name %}
 
 {% for n in range(properties['readReplicas']) %}
 - name: {{ replica_name }}-{{n}}
@@ -30,7 +30,7 @@ resources:
   metadata:
     dependsOn:
     {% if n == 0 %}
-    - database_name
+    - {{ database_name }}
     {% else %}
     - {{ replica_name + '-' + (n-1)|string }}
     {% endif %}

--- a/google/resource-snippets/compute-v1/alternatives-firewall/tf/firewall.tf
+++ b/google/resource-snippets/compute-v1/alternatives-firewall/tf/firewall.tf
@@ -1,0 +1,25 @@
+variable "deployment" {
+  type        = string
+  description = "Deployment name used to label the resources created."
+}
+
+variable "project_id" {
+  type        = string
+  description = "Project id used to create resources in that project."
+}
+
+provider "google" {
+  project = var.project_id
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}
+
+resource "google_compute_firewall" "default" {
+  name    = "address-${var.deployment}"
+  network = "https://www.googleapis.com/compute/v1/projects/${var.project_id}/global/networks/default"
+  source_ranges = ["0.0.0.0/0"]
+  deny {
+    protocol = "tcp"
+    ports    = ["11234", "16180"]
+  }
+}

--- a/google/resource-snippets/compute-v1/test_alternatives_firewall.sh
+++ b/google/resource-snippets/compute-v1/test_alternatives_firewall.sh
@@ -1,0 +1,69 @@
+set -e
+
+# The following variables are expected to be defined before running this script
+# PROJECT_ID=[PROJECT_ID]
+
+GREEN_COLOR='\033[0;32m'
+RED_COLOR='\033[0;31m'
+RESET_COLOR='\033[0m'
+
+provision_using_dm() {
+  gcloud deployment-manager deployments create deployment --config firewall.yaml
+  gcloud compute firewall-rules describe address-deployment --project=${PROJECT_ID} --format=yaml \
+      | sed "s/${PROJECT_ID}/PROJECT/" | sed "s/creationTimestamp: .*/creationTimestamp: TIME/" \
+      | sed "s/id: .*/id: ID/" \
+      > /tmp/dm.yaml
+  gcloud deployment-manager deployments delete deployment -q
+}
+
+provision_using_tf() {
+  if [[ -z "${GOOGLE_CREDENTIALS}" ]]; then
+    # For Compute, the ADC will have sufficient permissions
+    echo "Fetching Application Default Credentials for Terraform"
+    gcloud auth application-default login
+    export GOOGLE_CREDENTIALS=~/.config/gcloud/application_default_credentials.json
+  fi
+
+  cp -R alternatives-firewall/tf/ /tmp/firewall_tf_"${PROJECT_ID}"
+  pushd /tmp/firewall_tf_"${PROJECT_ID}"
+  terraform init
+  terraform plan -var="deployment=deployment" -var="project_id=${PROJECT_ID}"
+  terraform apply -auto-approve -var="deployment=deployment" -var="project_id=${PROJECT_ID}"
+  gcloud compute firewall-rules describe address-deployment --project=${PROJECT_ID} --format=yaml \
+      | sed "s/${PROJECT_ID}/PROJECT/" | sed "s/creationTimestamp: .*/creationTimestamp: TIME/" \
+      | sed "s/id: .*/id: ID/" \
+      > /tmp/tf.yaml
+  terraform destroy -auto-approve -var="deployment=deployment" -var="project_id=${PROJECT_ID}"
+  popd
+  rm -rf /tmp/firewall_tf_${PROJECT_ID}
+}
+
+gcloud config set project "${PROJECT_ID}"
+
+if [[ -n $( gcloud auth list --filter=status:ACTIVE --format="value(account)" ) ]]; then
+  account_name=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
+  echo "Reusing $account_name user credentials"
+else
+  gcloud auth login
+fi
+
+gcloud services enable compute.googleapis.com
+gcloud services enable deploymentmanager.googleapis.com
+
+provision_using_dm
+provision_using_tf
+# TODO [#652]: Implement provision_using_krm() and call it here.
+
+if [[ -n $(diff /tmp/dm.yaml /tmp/tf.yaml) ]]; then
+    echo -e "${RED_COLOR}TF and DM outputs are NOT identical${RESET_COLOR}"
+    echo "diff /tmp/dm.yaml /tmp/tf.yaml"
+    diff /tmp/dm.yaml /tmp/tf.yaml
+    exit 1
+else
+    echo -e "${GREEN_COLOR}TF and DM outputs are identical${RESET_COLOR}"
+fi
+
+# TODO [#652]: Compare KRM and DM outputs.
+
+echo -e "${GREEN_COLOR}Test Success${RESET_COLOR}"
+exit 0


### PR DESCRIPTION
TF alternative for compute-v1 firewall, and test script that deploys via both DM and TF and compares the results.

Closes #653.
