### PR TITLE
Update BigQuery template to include GET query parameter

### DIFF
--- a/google/resource-snippets/bigquery-v2/bigquery.jinja
+++ b/google/resource-snippets/bigquery-v2/bigquery.jinja
@@ -34,3 +34,8 @@ resources:
     datasetId: $(ref.{{ DATASET }}-test.datasetReference.datasetId)
     tableReference:
       tableId: {{ TABLE }}
+# tableMetadataView property allows consumers to set the query parameter
+# used on GET requests
+    {% if properties and properties["tableMetadataView"] %}
+    tableMetadataView: {{ properties["tableMetadataView"] }}
+    {% endif %}


### PR DESCRIPTION
BigQuery recently added a new query parameter to their tables.get method that required us to add a new property that maps to it. To avoid conflict with the existing table `view` property, users can now specify the `tableMetadataView` property on bigquery table  resources which will control what is returned on GET requests.