### PR TITLE
Update GKE container types to not use Docker types

### DIFF
--- a/google/resource-snippets/container-v1/gke_provider_cluster.jinja.schema
+++ b/google/resource-snippets/container-v1/gke_provider_cluster.jinja.schema
@@ -29,10 +29,10 @@ properties:
   imageType:
     type: string
     description: Image type of the cluster's node pool (cos or ubuntu)
-    default: cos
+    default: cos_containerd
     enum:
-    - cos
-    - container_vm
+    - cos_containerd
+    - ubuntu_containerd
   autoscaling:
     type: boolean
     description: True if node pool should autoscale.


### PR DESCRIPTION
GKE in the future will no longer support Docker image types. As such we need to update our configurations to use the supported containerd types instead.

Supported image types available at https://cloud.google.com/kubernetes-engine/docs/concepts/node-images