### PR TITLE
Update nodejs runtime for creating cloud functions

### DIFF
--- a/google/resource-snippets/cloudfunctions-v1/configurable_functions.yaml
+++ b/google/resource-snippets/cloudfunctions-v1/configurable_functions.yaml
@@ -21,4 +21,4 @@ resources:
   properties:
      region: REGION_TO_RUN
      entryPoint: handler
-     runtime: nodejs8
+     runtime: nodejs18

--- a/google/resource-snippets/cloudfunctions-v1/empty_bucket_in_function.yaml
+++ b/google/resource-snippets/cloudfunctions-v1/empty_bucket_in_function.yaml
@@ -21,4 +21,4 @@ resources:
   properties:
      region: REGION_TO_RUN
      entryPoint: handler
-     runtime: nodejs8
+     runtime: nodejs18


### PR DESCRIPTION
The nodejs8 runtime is no longer supported for cloud function. Thic PR upgrades from nodejs8 to nodejs18 (which is recommended). [More about cloud function runtime here](https://cloud.google.com/functions/docs/concepts/nodejs-runtime)