### PR TITLE
Update python runtime version to 3.7 from 2.7

### DIFF
--- a/google/resource-snippets/monitoring-v3/uptime_check_configs.jinja
+++ b/google/resource-snippets/monitoring-v3/uptime_check_configs.jinja
@@ -28,7 +28,7 @@ resources:
           scriptPath: main.app
         securityLevel: SECURE_OPTIONAL
         urlRegex: /
-    runtime: python27
+    runtime: python37
     threadsafe: true
 
 


### PR DESCRIPTION
Runtime python27 is end of support and no longer allowed for App Engine. We are are updating to python37. https://g3doc.corp.google.com/company/gfw/support/cloud/products/app-engine/python3_7.md?cl=head