### PR TITLE
Update entrypoint field in the version yaml file

### DIFF
--- a/google/resource-snippets/appengine-v1/version.jinja
+++ b/google/resource-snippets/appengine-v1/version.jinja
@@ -29,4 +29,6 @@ resources:
         securityLevel: SECURE_OPTIONAL
         urlRegex: /
     runtime: python37
+    entrypoint:
+      shell: ''
     threadsafe: true


### PR DESCRIPTION
Update entrypoint field in the version yaml file. This is required to mitigate the below error.

`Please update to the latest version of gcloud. If you are using the API directly, please provide a value for version.entrypoint.shell. This can be an empty value.`