### PR TITLE
Update entrypoint field in the version

### DIFF
--- a/google/resource-snippets/monitoring-v3/uptime_check_configs.jinja
+++ b/google/resource-snippets/monitoring-v3/uptime_check_configs.jinja
@@ -29,6 +29,8 @@ resources:
         securityLevel: SECURE_OPTIONAL
         urlRegex: /
     runtime: python37
+    entrypoint:
+      shell: ''
     threadsafe: true
 
 


### PR DESCRIPTION
Update entrypoint field in the version. This is required to mitigate the below error.

`Please update to the latest version of gcloud. If you are using the API directly, please provide a value for version.entrypoint.shell. This can be an empty value.`